### PR TITLE
split the data and the model pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # private data, except of the pipeline test snippet
 data/*
 !data/english_pipeline_test_head.jsonlines
+!data/data_utils.py
 
 # big cached data
 *.pickle

--- a/config.toml
+++ b/config.toml
@@ -11,8 +11,6 @@ data_dir = "data"
 train_data = "data/english_train_head.jsonlines"
 dev_data = "data/english_development_head.jsonlines"
 test_data = "data/english_test_head.jsonlines"
-# path to the test file for a pipeline test
-pipeline_test_data = "data/english_pipeline_test_head.jsonlines"
 
 # The device where everything is to be placed. "cuda:N"/"cpu" are supported.
 device = "cuda"
@@ -124,7 +122,9 @@ bert_window_size = 2048
 [debug]
 bert_window_size = 384
 bert_finetune = false
-device = "cpu:0"
+device = "cpu"
+# path to the test file for a pipeline test
+test_data = "data/english_pipeline_test_head.jsonlines"
 
 [debug_gpu]
 bert_window_size = 384

--- a/coref/config.py
+++ b/coref/config.py
@@ -7,9 +7,13 @@ import toml
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 from pathlib import Path
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, AutoModel
 from coref import bert
 
+@dataclass
+class ModelConfig:
+    encoder: AutoModel
+    tokenizer: AutoTokenizer
 
 @dataclass
 class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-methods
@@ -48,14 +52,17 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
     bce_loss_weight: float
 
     tokenizer_kwargs: Dict[str, dict]
-    tokenizer: AutoTokenizer = field(init=False)
+
+    model_bank: ModelConfig = field(init=False)
 
     conll_log_dir: str
 
     def __post_init__(self):
         with open(self.train_data, "r") as f:
             self.num_of_training_docs = sum(1 for _ in f)
-        _, self.tokenizer = bert.load_bert(self)
+        encoder, tokenizer = bert.load_bert(self)
+        self.model_bank =  ModelConfig(encoder, tokenizer)
+
 
     @staticmethod
     def load_config(config_path: str, section: str = "roberta") -> "Config":

--- a/coref/config.py
+++ b/coref/config.py
@@ -5,8 +5,10 @@ For description of all config values, refer to config.toml.
 import toml
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from pathlib import Path
+from transformers import AutoTokenizer
+from coref import bert
 
 
 @dataclass
@@ -17,11 +19,9 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
 
     data_dir: str
 
-    train_data: str
-    dev_data: str
-    test_data: str
-    # TODO This doesnt look like a good fit. Maybe config override for test purposes?
-    pipeline_test_data: str
+    train_data: Path
+    dev_data: Path
+    test_data: Path
 
     num_of_training_docs: int = field(init=False)
 
@@ -48,11 +48,14 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
     bce_loss_weight: float
 
     tokenizer_kwargs: Dict[str, dict]
+    tokenizer: AutoTokenizer = field(init=False)
+
     conll_log_dir: str
 
     def __post_init__(self):
-        with open(Path(self.train_data), "r") as f:
+        with open(self.train_data, "r") as f:
             self.num_of_training_docs = sum(1 for _ in f)
+        _, self.tokenizer = bert.load_bert(self)
 
     @staticmethod
     def load_config(config_path: str, section: str = "roberta") -> "Config":
@@ -60,12 +63,25 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
         default_section = config["DEFAULT"]
         current_section = config[section]
         unknown_keys = set(current_section.keys()) - set(default_section.keys())
+        updated_path_type = strs_2_paths(default_section, current_section)
         if unknown_keys:
             raise ValueError(f"Unexpected config keys: {unknown_keys}")
-        return Config(section, **{**default_section, **current_section})
+        return Config(
+            section, **{**default_section, **current_section, **updated_path_type}
+        )
 
     @staticmethod
     def load_default_config(section: Optional[str]) -> "Config":
         if section is not None:
             return Config.load_config("config.toml", section)
         return Config.load_config("config.toml")
+
+
+def strs_2_paths(
+    default_dict: Dict[str, Any], current_dict: Dict[str, Any]
+) -> Dict[str, Path]:
+    return {
+        "train_data": Path(current_dict.get("train_data", default_dict["train_data"])),
+        "dev_data": Path(current_dict.get("dev_data", default_dict["dev_data"])),
+        "test_data": Path(current_dict.get("test_data", default_dict["test_data"])),
+    }

--- a/coref/coref_model.py
+++ b/coref/coref_model.py
@@ -2,13 +2,11 @@
 
 from datetime import datetime
 import os
-import pickle
 import random
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np  # type: ignore
-import jsonlines  # type: ignore
 import torch
 from tqdm import tqdm  # type: ignore
 import transformers  # type: ignore

--- a/coref/data_utils.py
+++ b/coref/data_utils.py
@@ -1,3 +1,7 @@
+"""
+This module is responsible for reading json-line data and its tokenization.
+"""
+
 import pickle
 import jsonlines
 

--- a/coref/test_data_utils.py
+++ b/coref/test_data_utils.py
@@ -1,0 +1,8 @@
+from coref.config import Config
+from coref.data_utils import get_docs, DataType
+
+def test_get_doc():
+    config = Config.load_default_config(section="debug")
+    data = get_docs(DataType.test, config)
+    assert len(data) == 1
+    assert data[0]["document_id"] == "bc/cctv/00/cctv_0000"

--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -1,0 +1,65 @@
+import pickle
+import jsonlines
+
+from coref.tokenizer_customization import TOKENIZER_FILTERS, TOKENIZER_MAPS
+from pathlib import Path
+from typing import List
+from coref.config import Config
+from coref.const import Doc
+from dataclasses import asdict
+
+from enum import Enum
+
+
+class DataType(Enum):
+    train = "train_data"
+    test = "test_data"
+    dev = "dev_data"
+
+
+def tokenize_docs(path: Path, config: Config) -> List[Doc]:
+    print(f"Tokenizing documents at {path}...", flush=True)
+    out: List[Doc] = []
+    filter_func = TOKENIZER_FILTERS.get(config.bert_model, lambda _: True)
+    token_map = TOKENIZER_MAPS.get(config.bert_model, {})
+    with jsonlines.open(path, mode="r") as data_f:
+        for doc in data_f:
+            doc["span_clusters"] = [
+                [tuple(mention) for mention in cluster]
+                for cluster in doc["span_clusters"]
+            ]
+            word2subword = []
+            subwords = []
+            word_id = []
+            for i, word in enumerate(doc["cased_words"]):
+                tokenized_word = (
+                    token_map[word]
+                    if word in token_map
+                    else config.tokenizer.tokenize(word)
+                )
+                tokenized_word = list(filter(filter_func, tokenized_word))
+                word2subword.append(
+                    (len(subwords), len(subwords) + len(tokenized_word))
+                )
+                subwords.extend(tokenized_word)
+                word_id.extend([i] * len(tokenized_word))
+            doc["word2subword"] = word2subword
+            doc["subwords"] = subwords
+            doc["word_id"] = word_id
+            out.append(doc)
+    print("Tokenization OK", flush=True)
+    return out
+
+
+def get_docs(data_type: DataType, config: Config) -> List[Doc]:
+    path = asdict(config)[data_type.value]
+    model_name = config.bert_model.replace("/", "_")
+    cache_filename = Path(f"{model_name}_{path.name}.pickle")
+    if cache_filename.exists():
+        with open(cache_filename, mode="rb") as cache_f:
+            docs = pickle.load(cache_f)
+    else:
+        docs = tokenize_docs(path, config)
+        with open(cache_filename, mode="wb") as cache_f:
+            pickle.dump(docs, cache_f)
+    return docs

--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -35,7 +35,7 @@ def tokenize_docs(path: Path, config: Config) -> List[Doc]:
                 tokenized_word = (
                     token_map[word]
                     if word in token_map
-                    else config.tokenizer.tokenize(word)
+                    else config.model_bank.tokenizer.tokenize(word)
                 )
                 tokenized_word = list(filter(filter_func, tokenized_word))
                 word2subword.append(

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ import torch  # type: ignore
 
 from coref import CorefModel
 from coref.config import Config
-from data.data_utils import get_docs, DataType
+from coref.data_utils import get_docs, DataType
 
 
 @contextmanager

--- a/test_model.py
+++ b/test_model.py
@@ -1,15 +1,16 @@
 from coref import CorefModel
 from coref.config import Config
 from run import output_running_time
+from data.data_utils import get_docs, DataType
 
 
 def test_pipeline():
-    data_split = "pipeline_test"
     word_level = False
 
     config = Config.load_default_config(section="debug")
+    data = get_docs(DataType.test, config)
 
     model = CorefModel(config)
     # no weights are loaded. Random init to test forward step
     with output_running_time():
-        model.evaluate(data_split=data_split, word_level_conll=word_level)
+        model.evaluate(data, word_level_conll=word_level)

--- a/test_model.py
+++ b/test_model.py
@@ -1,7 +1,7 @@
 from coref import CorefModel
 from coref.config import Config
 from run import output_running_time
-from data.data_utils import get_docs, DataType
+from coref.data_utils import get_docs, DataType
 
 
 def test_pipeline():


### PR DESCRIPTION
The pipeline now passes the list of documents to both trainer and evaluator rather than loading them in their functions. This is done in order to train on different documents in the active learning loop

https://app.asana.com/0/1203072224624647/1203072224624661