### PR TITLE
add mc droupout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,8 +23,10 @@
         # Must be less than or equal to 512
         bert_window_size = 512
 
-
         # General model settings =============
+
+        # Coref model name
+        coref_model = "base"
 
         # Controls the dimensionality of feature embeddings
         embedding_size = 20
@@ -99,6 +101,11 @@
         # the total number of planned samplings
         total_number_of_iterations = 10
 
+    [DEFAULT.active_learning]
+        # Active Learning parameters
+        # Number of neural network parameters that will represent NN empirical distribution
+        parameters_samples = 10
+
 
     # =============================================================================
     # Extra keyword arguments to be passed to bert tokenizers of specified models
@@ -159,6 +166,10 @@
         strategy_flip = 0.2
         total_number_of_iterations = 10
 
+[mc_dropout]
+    [mc_dropout.model_params]
+        bert_model = "roberta-large"
+        coref_model = "mc_dropout"
 
 [debug_gpu]
     [debug_gpu.model_params]

--- a/config/config.py
+++ b/config/config.py
@@ -15,6 +15,12 @@ from coref.bert import load_bert
 from config.config_utils import overwrite_config
 
 
+@overwrite_config
+@dataclass
+class ActiveLearning:
+    parameters_samples: int
+
+
 @dataclass
 class ModelBank:
     encoder: AutoModel
@@ -56,6 +62,9 @@ class ModelParams:
     bert_model: str
     bert_window_size: int
 
+    # TODO Change to enum in load config for this class
+    coref_model: str
+
     embedding_size: int
     sp_embedding_size: int
     a_scoring_batch_size: int
@@ -95,6 +104,8 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
     # AL sampling_strategy. Will be added to AL section later
     sampling_strategy: GreedySampling
 
+    active_learning: ActiveLearning
+
     model_bank: ModelBank = field(init=False)
 
     def __post_init__(self) -> None:
@@ -123,20 +134,26 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
             overwrite_conf.get("training_params", {}),
         )
 
-        tokenizer_kwards = default_conf["tokenizer_kwargs"]
+        tokenizer_kwargs = default_conf["tokenizer_kwargs"]
 
         sampling_strategy = GreedySampling.load_config(
             default_conf["sampling_strategy"],
             overwrite_conf.get("sampling_strategy", {}),
         )
 
+        active_learning = ActiveLearning(  # type: ignore[call-arg]
+            default_conf["active_learning"],
+            overwrite_conf.get("active_learning", {}),
+        )
+
         return Config(
-            section,
-            data,
-            model_params,
-            training_params,
-            tokenizer_kwards,
-            sampling_strategy,
+            section=section,
+            data=data,
+            model_params=model_params,
+            training_params=training_params,
+            tokenizer_kwargs=tokenizer_kwargs,
+            sampling_strategy=sampling_strategy,
+            active_learning=active_learning,
         )
 
     @staticmethod

--- a/coref/const.py
+++ b/coref/const.py
@@ -20,11 +20,14 @@ class SampledData:
 
 @dataclass
 class CorefResult:
+    # ensemble_coref_scores: List[torch.Tensor] = None # List[n_words, k + 1]
     coref_scores: torch.Tensor = None  # [n_words, k + 1]
     coref_y: torch.Tensor = None  # [n_words, k + 1]
 
+    # ensemble_word_cluster: Optional[List[List[List[int]]]] = None
     word_clusters: Optional[List[List[int]]] = None
     span_clusters: Optional[List[List[Span]]] = None
 
+    # ensemble_span_scores: Optional[torch.Tensor] = None  # [n_heads, n_words, 2]
     span_scores: Optional[torch.Tensor] = None  # [n_heads, n_words, 2]
     span_y: Optional[Tuple[torch.Tensor, torch.Tensor]] = None  # [n_heads] x2

--- a/coref/models/__init__.py
+++ b/coref/models/__init__.py
@@ -6,9 +6,22 @@
   model.evaluate("dev")
 """
 
+from config.config import Config
+
+from coref.models.mc_dropout_coref import MCDropoutCorefModel
 from coref.models.coref_model import CorefModel
+from coref.models.general_coref_model import GeneralCorefModel
 
 
 # When we will have more coref models, will define
 # them in config and resolve it here. Slaaaaaaaay!
-__all__ = ["CorefModel"]
+
+
+def load_coref_model(config: Config) -> GeneralCorefModel:
+    if config.model_params.coref_model == "base":
+        return CorefModel(config)
+    elif config.model_params.coref_model == "mc_dropout":
+        return MCDropoutCorefModel(config)
+    raise ValueError(
+        "Amigo, bad news... {config.model_params.coref_model} is not on the table..."
+    )

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -463,9 +463,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         self.rough_scorer = RoughScorer(bert_emb, self.config).to(
             self.config.training_params.device
         )
-        self.sp = SpanPredictor(
-            bert_emb, self.config.model_params.sp_embedding_size
-        ).to(self.config.training_params.device)
+        self.sp = SpanPredictor(bert_emb, self.config).to(
+            self.config.training_params.device
+        )
 
         self.trainable: Dict[str, torch.nn.Module] = {
             "bert": self.bert,

--- a/coref/models/mc_dropout_coref.py
+++ b/coref/models/mc_dropout_coref.py
@@ -16,7 +16,7 @@ from coref.span_predictor import MCDropoutSpanPredictor
 class MCDropoutCorefModel(GeneralCorefModel):
     def __init__(self, config: Config, epochs_trained: int = 0):
         # The approach works for all layers except of span_predictor
-        # The dropout is turned on inside MCDropoutSpanPredictor. 
+        # The dropout is turned on inside MCDropoutSpanPredictor.
         # TODO refactor keep _set_training from MCDropoutSpanPredictor
         self.keep_dropout: List["str"] = ["rough_scorer", "pw", "a_scorer"]
         super().__init__(config, epochs_trained)
@@ -28,7 +28,6 @@ class MCDropoutCorefModel(GeneralCorefModel):
                 module.train(self._training)
             else:
                 module.train(True)
-
 
     def _build_model(self) -> None:
         self.bert = self.config.model_bank.encoder
@@ -50,9 +49,9 @@ class MCDropoutCorefModel(GeneralCorefModel):
         self.rough_scorer = MCDropoutRoughScorer(bert_emb, self.config).to(
             self.config.training_params.device
         )
-        self.sp = MCDropoutSpanPredictor(
-            bert_emb, self.config
-        ).to(self.config.training_params.device)
+        self.sp = MCDropoutSpanPredictor(bert_emb, self.config).to(
+            self.config.training_params.device
+        )
 
         self.trainable: Dict[str, torch.nn.Module] = {
             "bert": self.bert,

--- a/coref/models/mc_dropout_coref.py
+++ b/coref/models/mc_dropout_coref.py
@@ -1,0 +1,64 @@
+import torch
+
+from typing import List, Dict
+
+from coref.models.general_coref_model import GeneralCorefModel
+from config import Config
+from coref.const import Doc, CorefResult
+
+from coref.anaphoricity_scorer import MCDropoutAnaphoricityScorer
+from coref.pairwise_encoder import MCDropoutPairwiseEncoder
+from coref.word_encoder import WordEncoder
+from coref.rough_scorer import MCDropoutRoughScorer
+from coref.span_predictor import MCDropoutSpanPredictor
+
+
+class MCDropoutCorefModel(GeneralCorefModel):
+    def __init__(self, config: Config, epochs_trained: int = 0):
+        # The approach works for all layers except of span_predictor
+        # The dropout is turned on inside MCDropoutSpanPredictor. 
+        # TODO refactor keep _set_training from MCDropoutSpanPredictor
+        self.keep_dropout: List["str"] = ["rough_scorer", "pw", "a_scorer"]
+        super().__init__(config, epochs_trained)
+
+    def _set_training(self, value: bool) -> None:
+        self._training = value
+        for name, module in self.trainable.items():
+            if name not in self.keep_dropout:
+                module.train(self._training)
+            else:
+                module.train(True)
+
+
+    def _build_model(self) -> None:
+        self.bert = self.config.model_bank.encoder
+        self.tokenizer = self.config.model_bank.tokenizer
+        self.pw = MCDropoutPairwiseEncoder(self.config).to(
+            self.config.training_params.device
+        )
+
+        bert_emb = self.bert.config.hidden_size
+        pair_emb = bert_emb * 3 + self.pw.shape
+
+        # pylint: disable=line-too-long
+        self.a_scorer = MCDropoutAnaphoricityScorer(pair_emb, self.config).to(
+            self.config.training_params.device
+        )
+        self.we = WordEncoder(bert_emb, self.config).to(
+            self.config.training_params.device
+        )
+        self.rough_scorer = MCDropoutRoughScorer(bert_emb, self.config).to(
+            self.config.training_params.device
+        )
+        self.sp = MCDropoutSpanPredictor(
+            bert_emb, self.config
+        ).to(self.config.training_params.device)
+
+        self.trainable: Dict[str, torch.nn.Module] = {
+            "bert": self.bert,
+            "we": self.we,
+            "rough_scorer": self.rough_scorer,
+            "pw": self.pw,
+            "a_scorer": self.a_scorer,
+            "sp": self.sp,
+        }

--- a/coref/span_predictor.py
+++ b/coref/span_predictor.py
@@ -3,13 +3,14 @@ head word and context embeddings.
 """
 
 from typing import List, Optional, Tuple
+from config.config import Config
 
 from coref.const import Doc, Span
 import torch
 
 
 class SpanPredictor(torch.nn.Module):
-    def __init__(self, input_size: int, distance_emb_size: int):
+    def __init__(self, input_size: int, config: Config):
         super().__init__()
         self.ffnn = torch.nn.Sequential(
             torch.nn.Linear(input_size * 2 + 64, input_size),
@@ -24,7 +25,7 @@ class SpanPredictor(torch.nn.Module):
             torch.nn.Conv1d(64, 4, 3, 1, 1), torch.nn.Conv1d(4, 2, 3, 1, 1)
         )
         self.emb = torch.nn.Embedding(
-            128, distance_emb_size
+            128, config.model_params.sp_embedding_size
         )  # [-63, 63] + too_far
 
     @property
@@ -164,3 +165,107 @@ class SpanPredictor(torch.nn.Module):
         }
 
         return [[head2span[head] for head in cluster] for cluster in clusters]
+
+
+class MCDropoutSpanPredictor(SpanPredictor):
+    def __init__(self, input_size: int, config: Config):
+        self.parameters_samples = config.active_learning.parameters_samples
+        super().__init__(input_size, config)
+
+    def forward(
+        self,  # type: ignore  # pylint: disable=arguments-differ  #35566 in pytorch
+        doc: Doc,
+        words: torch.Tensor,
+        heads_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Calculates span start/end scores of words for each span head in
+        heads_ids
+
+        Args:
+            doc (Doc): the document data
+            words (torch.Tensor): contextual embeddings for each word in the
+                document, [n_words, emb_size]
+            heads_ids (torch.Tensor): word indices of span heads
+
+        Returns:
+            torch.Tensor: span start/end scores, [n_heads, n_words, 2]
+        """
+        # Obtain distance embedding indices, [n_heads, n_words]
+        relative_positions = heads_ids.unsqueeze(1) - torch.arange(
+            words.shape[0], device=words.device
+        ).unsqueeze(0)
+        emb_ids = relative_positions + 63  # make all valid distances positive
+        emb_ids[(emb_ids < 0) + (emb_ids > 126)] = 127  # "too_far"
+
+        # Obtain "same sentence" boolean mask, [n_heads, n_words]
+        sent_id = torch.tensor(doc["sent_id"], device=words.device)
+        same_sent = sent_id[heads_ids].unsqueeze(1) == sent_id.unsqueeze(0)
+
+        # To save memory, only pass candidates from one sentence for each head
+        # pair_matrix contains concatenated span_head_emb + candidate_emb + distance_emb
+        # for each candidate among the words in the same sentence as span_head
+        # [n_heads, input_size * 2 + distance_emb_size]
+        rows, cols = same_sent.nonzero(as_tuple=True)
+        pair_matrix = torch.cat(
+            (
+                words[heads_ids[rows]],
+                words[cols],
+                self.emb(emb_ids[rows, cols]),
+            ),
+            dim=1,
+        )
+
+        lengths = same_sent.sum(dim=1)
+        padding_mask = torch.arange(
+            0, lengths.max(), device=words.device
+        ).unsqueeze(0)
+        padding_mask = padding_mask < lengths.unsqueeze(
+            1
+        )  # [n_heads, max_sent_len]
+
+        # [n_heads, max_sent_len, input_size * 2 + distance_emb_size]
+        # This is necessary to allow the convolution layer to look at several
+        # word scores
+        padded_pairs = torch.zeros(
+            *padding_mask.shape, pair_matrix.shape[-1], device=words.device
+        )
+        padded_pairs[padding_mask] = pair_matrix
+
+        # TODO Find a better way how to handle that
+        back_2_eval = False
+        self.training: bool
+        if not self.training:
+            back_2_eval = True
+            self.training = True
+        res = torch.mean(
+            torch.stack(
+                [
+                    self.ffnn(
+                        padded_pairs
+                    )  # [n_heads, n_candidates, last_layer_output]
+                    for _ in range(self.parameters_samples)
+                ]
+            ),
+            dim=0,
+        )
+        if back_2_eval:
+            self.training = False
+        res = self.conv(res.permute(0, 2, 1)).permute(
+            0, 2, 1
+        )  # [n_heads, n_candidates, 2]
+
+        scores = torch.full(
+            (heads_ids.shape[0], words.shape[0], 2),
+            float("-inf"),
+            device=words.device,
+        )
+        scores[rows, cols] = res[padding_mask]
+
+        # Make sure that start <= head <= end during inference
+        if not self.training:
+            valid_starts = torch.log((relative_positions >= 0).to(torch.float))
+            valid_ends = torch.log((relative_positions <= 0).to(torch.float))
+            valid_positions = torch.stack((valid_starts, valid_ends), dim=2)
+            return scores + valid_positions
+        return scores

--- a/run.py
+++ b/run.py
@@ -14,7 +14,7 @@ from typing import Iterator
 import numpy as np  # type: ignore
 import torch  # type: ignore
 
-from coref.models import CorefModel
+from coref.models import load_coref_model
 from config import Config
 from coref.data_utils import get_docs, DataType
 
@@ -88,7 +88,7 @@ if __name__ == "__main__":
 
     # Load config
     config = Config.load_config(args.config_file, args.experiment)
-    model = CorefModel(config)
+    model = load_coref_model(config)
 
     # Load data
     train_data = get_docs(DataType.train, config=config)

--- a/test_model.py
+++ b/test_model.py
@@ -1,4 +1,4 @@
-from coref.models import CorefModel
+from coref.models import load_coref_model
 from config import Config
 from run import output_running_time
 from coref.data_utils import get_docs, DataType
@@ -10,7 +10,7 @@ def test_pipeline() -> None:
     config = Config.load_default_config(section="debug")
     data = get_docs(DataType.test, config)
 
-    model = CorefModel(config)
+    model = load_coref_model(config)
     # no weights are loaded. Random init to test forward step
     with output_running_time():
         model.evaluate(data, word_level_conll=word_level)


### PR DESCRIPTION
Adding MC Dropout configuration. For now we cannot work with the uncertainty. At the current moment the
model aggregates the weights inside. So, in the next iteration we will have to add uncertainty to results

Base model output for eval
```
0.75366, r: 0.80646: 100% 348/348 [00:31<00:00, 10.96docs/s]
```
Mc dropout output for eval
```
0.75413, r: 0.80859: 100% 348/348 [01:29<00:00,  3.90docs/s]
```