### PR TITLE
Span sampling

### DIFF
--- a/active_learning/test_acquisition_functions.py
+++ b/active_learning/test_acquisition_functions.py
@@ -9,10 +9,10 @@ def test_random_sampling(dev_data: list[Doc]) -> None:
     instances = 10 * dev_data  # we have only one debug doc, so make 10
     sampled_data = random_sampling(instances, BATCH_SIZE)
     assert len(sampled_data.indices) == BATCH_SIZE
-    assert sampled_data.instances[0]["document_id"] == "bc/cctv/00/cctv_0000"
+    assert sampled_data.instances[0].document_id == "bc/cctv/00/cctv_0000"
 
 
 def test_random_sampling_w_too_large_batch_size(dev_data: list[Doc]) -> None:
     sampled_data = random_sampling(dev_data, TOO_LARGE_BATCH_SIZE)
     assert len(sampled_data.indices) == len(dev_data)
-    assert sampled_data.instances[0]["document_id"] == "bc/cctv/00/cctv_0000"
+    assert sampled_data.instances[0].document_id == "bc/cctv/00/cctv_0000"

--- a/config.toml
+++ b/config.toml
@@ -110,6 +110,9 @@
         # Number of neural network parameters that will represent NN empirical distribution
         parameters_samples = 10
 
+        # Turn on span sampling instead of documents sampling
+        span_sampling = false
+
         [DEFAULT.active_learning.simulation]
             # Simulation parameters (e.g. starting sample size, number of iterations, ...)
 

--- a/config.toml
+++ b/config.toml
@@ -254,3 +254,10 @@
         bert_window_size = 384
     [debug_gpu.training_params]
         bert_finetune = false
+
+# Active Learning
+[active_learning_simulation]
+    [active_learning.model_params]
+        bert_model = "roberta-large"
+[active_learning_simulation.active_learning]
+        span_sampling = true

--- a/config.toml
+++ b/config.toml
@@ -234,6 +234,9 @@
             epochs = 15
     [debug.logging]
         logger_name = "test_run"
+    [debug.active_learning]
+        span_sampling = true
+
 
 [mc_dropout]
     [mc_dropout.model_params]
@@ -257,7 +260,7 @@
 
 # Active Learning
 [active_learning_simulation]
-    [active_learning.model_params]
+    [active_learning_simulation.model_params]
         bert_model = "roberta-large"
 [active_learning_simulation.active_learning]
         span_sampling = true

--- a/config/active_learning.py
+++ b/config/active_learning.py
@@ -15,6 +15,8 @@ class Simulation:
 
 @dataclass
 class ActiveLearning:
+    # Span sampling instead of documents sampling
+    span_sampling: bool
     # Active Learning parameters
     parameters_samples: int
     # Active Learning sampling strategy.
@@ -25,11 +27,13 @@ class ActiveLearning:
     @staticmethod
     @overwrite_config
     def load_config(
+        span_sampling: bool,
         parameters_samples: int,
         sampling_strategy: dict[str, Any],
         simulation: dict[str, Any],
     ) -> "ActiveLearning":
         return ActiveLearning(
+            span_sampling,
             parameters_samples,
             GreedySampling.load_config(**sampling_strategy),
             Simulation(**simulation),

--- a/coref/bert.py
+++ b/coref/bert.py
@@ -1,6 +1,6 @@
 """Functions related to BERT or similar models"""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Any
 
 import numpy as np  # type: ignore
 from transformers import AutoModel, AutoTokenizer  # type: ignore
@@ -22,7 +22,7 @@ def get_subwords_batches(
     """
     batch_size = bert_window_size - 2  # to save space for CLS and SEP
 
-    subwords: List[int] = doc["subwords"]
+    subwords: List[str] = doc.subwords
     subwords_batches = []
     start, end = 0, 0
 
@@ -31,8 +31,8 @@ def get_subwords_batches(
 
         # Move back till we hit a sentence end
         if end < len(subwords):
-            sent_id = doc["sent_id"][doc["word_id"][end]]
-            while end and doc["sent_id"][doc["word_id"][end - 1]] == sent_id:
+            sent_id = doc.sent_id[doc.word_id[end]]
+            while end and doc.sent_id[doc.word_id[end - 1]] == sent_id:
                 end -= 1
 
         length = end - start

--- a/coref/conll.py
+++ b/coref/conll.py
@@ -16,10 +16,10 @@ def write_conll(doc: Doc, clusters: List[List[Span]], f_obj: TextIO) -> None:
     """Writes span/cluster information to f_obj, which is assumed to be a file
     object open for writing"""
     placeholder = "  -" * 7
-    doc_id = doc["document_id"]
-    words = doc["cased_words"]
-    part_id = doc["part_id"]
-    sents = doc["sent_id"]
+    doc_id = doc.document_id
+    words = doc.cased_words
+    part_id = doc.part_id
+    sents = doc.sent_id
 
     max_word_len = max(len(w) for w in words)
 

--- a/coref/const.py
+++ b/coref/const.py
@@ -8,14 +8,31 @@ import torch
 EPSILON = 1e-7
 LARGE_VALUE = 1000  # used instead of inf due to bug #16762 in pytorch
 
-Doc = Dict[str, Any]
 Span = Tuple[int, int]
 
 
 @dataclass
+class Doc:
+    document_id: str
+    cased_words: list[str]
+    sent_id: list[int]
+    part_id: int
+    speaker: list[str]
+    pos: list[str]
+    deprel: list[str]
+    head: Optional[list[str]]
+    head2span: list[list[int]]
+    word_clusters: list[list[int]]
+    span_clusters: list[list[Tuple[int, int]]]
+    word2subword: list[Tuple[int, int]]
+    subwords: list[str]
+    word_id: list[int]
+
+
+@dataclass
 class SampledData:
-    indices: List[int]
-    instances: List[Doc]
+    indices: list[int]
+    instances: list[Doc]
 
 
 @dataclass
@@ -23,8 +40,8 @@ class CorefResult:
     coref_scores: torch.Tensor = None  # [n_words, k + 1]
     coref_y: torch.Tensor = None  # [n_words, k + 1]
 
-    word_clusters: Optional[List[List[int]]] = None
-    span_clusters: Optional[List[List[Span]]] = None
+    word_clusters: Optional[list[list[int]]] = None
+    span_clusters: Optional[list[list[Span]]] = None
 
     span_scores: Optional[torch.Tensor] = None  # [n_heads, n_words, 2]
     span_y: Optional[Tuple[torch.Tensor, torch.Tensor]] = None  # [n_heads] x2

--- a/coref/const.py
+++ b/coref/const.py
@@ -1,7 +1,8 @@
 """ Contains type aliases for coref module """
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple, Optional
+from dataclasses import dataclass, field
+from typing import Tuple, Optional
+from itertools import chain
 
 import torch
 
@@ -9,6 +10,12 @@ EPSILON = 1e-7
 LARGE_VALUE = 1000  # used instead of inf due to bug #16762 in pytorch
 
 Span = Tuple[int, int]
+
+
+@dataclass
+class SimulationSpanAnnotations:
+    spans: list[Tuple[int, int]]
+    old_2_new_ids_map: dict[int, int]
 
 
 @dataclass
@@ -27,6 +34,97 @@ class Doc:
     word2subword: list[Tuple[int, int]]
     subwords: list[str]
     word_id: list[int]
+    simulation_span_annotations: SimulationSpanAnnotations = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.simulation_span_annotations = SimulationSpanAnnotations([], {})
+
+    def create_simulation_pseudodoc(self) -> "Doc":
+
+        if not self.simulation_span_annotations.spans:
+            word_ids = list(range(len(self.cased_words)))
+        else:
+            # get the word ids that are in spans
+            word_ids = sorted(
+                set(
+                    [
+                        word
+                        for start, end in self.simulation_span_annotations.spans
+                        for word in range(start, end)
+                    ]
+                )
+            )
+        # create the mapping
+        new_w_ids_map: dict[int, int] = {
+            w_id: new_w_id
+            for w_id, new_w_id in zip(word_ids, range(len(word_ids)))
+        }
+
+        # reindex head to spans
+        head2span: list[list[int]] = []
+        for head, start, end in self.head2span:
+            if head in new_w_ids_map and start in new_w_ids_map:
+                reindexed_head2span = [
+                    new_w_ids_map[head],
+                    new_w_ids_map[start],
+                    new_w_ids_map[start] + (end - start),
+                ]
+                head2span.append(reindexed_head2span)
+
+        # reindex word clusters
+        word_clusters: list[list[int]] = []
+        for cluster in self.word_clusters:
+            reindexed_cluster = [
+                new_w_ids_map[i] for i in cluster if i in new_w_ids_map
+            ]
+            if reindexed_cluster:
+                word_clusters.append(reindexed_cluster)
+
+        # reindex span clusters
+        span_clusters: list[list[Tuple[int, int]]] = []
+        for span_cluster in self.span_clusters:
+            reindexed_span_cluster: list[Tuple[int, int]] = [
+                (new_w_ids_map[start], new_w_ids_map[start] + end - start)
+                for start, end in span_cluster
+                if start in new_w_ids_map
+            ]
+            if reindexed_span_cluster:
+                span_clusters.append(reindexed_span_cluster)
+
+        # word to subword
+
+        #### FIX #####
+        word2subword: list[Tuple[int, int]] = []
+        shift = 0
+        for w in word_ids:
+            start, end = self.word2subword[w]
+            diff = end - start
+            word2subword.append((shift, shift + diff))
+            shift += diff
+            #     (new_w_ids_map[start], new_w_ids_map[start] + end - start)
+            # )
+
+        return Doc(
+            document_id=self.document_id,
+            cased_words=[self.cased_words[w] for w in word_ids],
+            sent_id=[self.sent_id[w] for w in word_ids],
+            part_id=self.part_id,
+            speaker=[self.speaker[w] for w in word_ids],
+            pos=[self.pos[w] for w in word_ids],
+            deprel=[self.deprel[w] for w in word_ids],
+            head=[],  # unused
+            head2span=head2span,
+            word_clusters=word_clusters,
+            span_clusters=span_clusters,
+            word2subword=word2subword,
+            subwords=[
+                word
+                for i, (start, end) in enumerate(self.word2subword)
+                if i in word_ids
+                for word in self.subwords[start:end]
+            ],
+            word_id=list(range(len(word_ids))),
+        )
 
 
 @dataclass

--- a/coref/const.py
+++ b/coref/const.py
@@ -20,7 +20,7 @@ class Doc:
     speaker: list[str]
     pos: list[str]
     deprel: list[str]
-    head: Optional[list[str]]
+    head: list[Optional[str]]
     head2span: list[list[int]]
     word_clusters: list[list[int]]
     span_clusters: list[list[Tuple[int, int]]]

--- a/coref/data_utils.py
+++ b/coref/data_utils.py
@@ -52,7 +52,7 @@ def tokenize_docs(path: Path, config: Config) -> List[Doc]:
             doc["word2subword"] = word2subword
             doc["subwords"] = subwords
             doc["word_id"] = word_id
-            out.append(doc)
+            out.append(Doc(**doc))
     print("Tokenization OK", flush=True)
     return out
 

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -290,10 +290,24 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         Returns:
             CorefResult (see const.py)
         """
+
+        # Rewrite the doc to a pseudo doc. This will use only spans, given in
+        # the simulation_span_annotations field. If the field is empty, the method
+        # will use all available annotated spans.
+        # N.B. The quality of encoding is not damaged because it is done on the whole
+        # article
+
         # Encode words with bert
+        encoded_doc = self._bertify(doc)
+
+        # if self.config.active_learning.span_sampling:
+        #     doc = doc.create_simulation_pseudodoc()
+        #     subwords_indices = [ for word in doc.word2subword]
+        #     encoded_doc =
+
         # words           [n_words, span_emb]
         # cluster_ids     [n_words]
-        words, cluster_ids = self.we(doc, self._bertify(doc))
+        words, cluster_ids = self.we(doc, encoded_doc)
 
         # Obtain bilinear scores and leave only top-k antecedents for each word
         # top_rough_scores  [n_words, n_ants]

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -300,10 +300,11 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         # Encode words with bert
         encoded_doc = self._bertify(doc)
 
-        # if self.config.active_learning.span_sampling:
-        #     doc = doc.create_simulation_pseudodoc()
-        #     subwords_indices = [ for word in doc.word2subword]
-        #     encoded_doc =
+        if self.config.active_learning.span_sampling:
+            doc = doc.create_simulation_pseudodoc()
+            encoded_doc = encoded_doc[
+                doc.simulation_span_annotations.original_subtokens_ids, :
+            ]
 
         # words           [n_words, span_emb]
         # cluster_ids     [n_words]

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -167,7 +167,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                         doc,
                         [
                             [(i, i + 1) for i in cluster]
-                            for cluster in doc["word_clusters"]
+                            for cluster in doc.word_clusters
                         ],
                         gold_f,
                     )
@@ -180,7 +180,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                         pred_f,
                     )
                 else:
-                    conll.write_conll(doc, doc["span_clusters"], gold_f)
+                    conll.write_conll(doc, doc.span_clusters, gold_f)
                     if res.span_clusters is None:
                         raise RuntimeError(
                             f'"span_clusters" attribute must be set'
@@ -188,13 +188,13 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                     conll.write_conll(doc, res.span_clusters, pred_f)
 
                 w_checker.add_predictions(
-                    doc["word_clusters"],
+                    doc.word_clusters,
                     cast(List[List[Hashable]], res.word_clusters),
                 )
                 w_lea = w_checker.total_lea
 
                 s_checker.add_predictions(
-                    doc["span_clusters"],
+                    doc.span_clusters,
                     cast(List[List[Hashable]], res.span_clusters),
                 )
                 s_lea = s_checker.total_lea
@@ -369,7 +369,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         Trains all the trainable blocks in the model using the config provided.
         """
         docs_ids = list(range(len(docs)))
-        avg_spans = sum(len(doc["head2span"]) for doc in docs) / len(docs)
+        avg_spans = sum(len(doc.head2span) for doc in docs) / len(docs)
 
         for epoch in range(
             self.epochs_trained, self.config.training_params.train_epochs
@@ -419,7 +419,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
                 pbar.set_description(
                     f"Epoch {epoch + 1}:"
-                    f" {doc['document_id']:26}"
+                    f" {doc.document_id:26}"
                     f" c_loss: {running_c_loss / (pbar.n + 1):<.5f}"
                     f" s_loss: {running_s_loss / (pbar.n + 1):<.5f}"
                 )
@@ -584,7 +584,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         coref_span_heads = torch.arange(0, len(scores))[not_dummy]
         antecedents = top_indices[coref_span_heads, antecedents[not_dummy]]
 
-        nodes = [GraphNode(i) for i in range(len(doc["cased_words"]))]
+        nodes = [GraphNode(i) for i in range(len(doc.cased_words))]
         for i, j in zip(coref_span_heads.tolist(), antecedents.tolist()):
             nodes[i].link(nodes[j])
             assert nodes[i] is not nodes[j]

--- a/coref/models/reduced_dimensionality_coref.py
+++ b/coref/models/reduced_dimensionality_coref.py
@@ -104,7 +104,7 @@ class ReducedDimensionalityCorefModel(GeneralCorefModel):
         Trains all the trainable blocks in the model using the config provided.
         """
         docs_ids = list(range(len(docs)))
-        avg_spans = sum(len(doc["head2span"]) for doc in docs) / len(docs)
+        avg_spans = sum(len(doc.head2span) for doc in docs) / len(docs)
 
         for epoch in range(
             self.epochs_trained, self.config.training_params.train_epochs

--- a/coref/pairwise_encoder.py
+++ b/coref/pairwise_encoder.py
@@ -49,7 +49,7 @@ class PairwiseEncoder(torch.nn.Module):
         top_indices: torch.Tensor,
         doc: Doc,
     ) -> torch.Tensor:
-        word_ids = torch.arange(0, len(doc["cased_words"]), device=self.device)
+        word_ids = torch.arange(0, len(doc.cased_words), device=self.device)
         speaker_map = torch.tensor(self._speaker_map(doc), device=self.device)
 
         same_speaker = speaker_map[top_indices] == speaker_map.unsqueeze(1)
@@ -65,7 +65,7 @@ class PairwiseEncoder(torch.nn.Module):
         distance = self.distance_emb(distance)
 
         genre = torch.tensor(
-            self.genre2int[doc["document_id"][:2]], device=self.device
+            self.genre2int[doc.document_id[:2]], device=self.device
         ).expand_as(top_indices)
         genre = self.genre_emb(genre)
 
@@ -80,10 +80,10 @@ class PairwiseEncoder(torch.nn.Module):
         Returns a tensor where i-th element is the speaker id of i-th word.
         """
         # speaker string -> speaker id
-        str2int = {s: i for i, s in enumerate(set(doc["speaker"]))}
+        str2int = {s: i for i, s in enumerate(set(doc.speaker))}
 
         # word id -> speaker id
-        return [str2int[s] for s in doc["speaker"]]
+        return [str2int[s] for s in doc.speaker]
 
 
 class MCDropoutPairwiseEncoder(PairwiseEncoder):

--- a/coref/span_predictor.py
+++ b/coref/span_predictor.py
@@ -61,7 +61,7 @@ class SpanPredictor(torch.nn.Module):
         emb_ids[(emb_ids < 0) + (emb_ids > 126)] = 127  # "too_far"
 
         # Obtain "same sentence" boolean mask, [n_heads, n_words]
-        sent_id = torch.tensor(doc["sent_id"], device=words.device)
+        sent_id = torch.tensor(doc.sent_id, device=words.device)
         same_sent = sent_id[heads_ids].unsqueeze(1) == sent_id.unsqueeze(0)
 
         # To save memory, only pass candidates from one sentence for each head
@@ -125,7 +125,7 @@ class SpanPredictor(torch.nn.Module):
         Optional[torch.Tensor], Optional[Tuple[torch.Tensor, torch.Tensor]]
     ]:
         """Returns span starts/ends for gold mentions in the document."""
-        head2span = sorted(doc["head2span"])
+        head2span = sorted(doc.head2span)
         if not head2span:
             return None, None
         heads, starts, ends = zip(*head2span)

--- a/coref/test_const.py
+++ b/coref/test_const.py
@@ -39,3 +39,13 @@ def test_create_simulation_pseudodoc(dev_data: list[Doc]) -> None:
     ]
     assert pseudo_doc.head2span == [[0, 0, 1], [1, 1, 2], [4, 2, 5], [7, 5, 8]]
     assert pseudo_doc.span_clusters == [[(0, 1), (1, 2)], [(2, 5), (5, 8)]]
+    assert pseudo_doc.word2subword == [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 8),
+    ]

--- a/coref/test_const.py
+++ b/coref/test_const.py
@@ -1,0 +1,41 @@
+from coref.const import Doc
+
+
+def test_create_simulation_pseudodoc(dev_data: list[Doc]) -> None:
+    # We can use only one doc
+    # Create the pseudo doc from an existing one
+    doc = dev_data[0]
+    pseudo_doc = doc.create_simulation_pseudodoc()
+    assert doc.document_id == pseudo_doc.document_id
+    assert doc.cased_words == pseudo_doc.cased_words
+    assert doc.sent_id == pseudo_doc.sent_id
+    assert doc.part_id == pseudo_doc.part_id
+    assert doc.speaker == pseudo_doc.speaker
+    assert doc.pos == pseudo_doc.pos
+    assert doc.deprel == pseudo_doc.deprel
+    assert doc.head2span == pseudo_doc.head2span
+    assert doc.span_clusters == pseudo_doc.span_clusters
+    assert doc.word2subword == pseudo_doc.word2subword
+    assert doc.subwords == pseudo_doc.subwords
+
+    # Create a pseudo doc from
+    doc.simulation_span_annotations.spans = [
+        (55, 56),
+        (70, 71),
+        (377, 380),
+        (411, 414),
+    ]
+    pseudo_doc = doc.create_simulation_pseudodoc()
+    assert doc.document_id == pseudo_doc.document_id
+    assert pseudo_doc.cased_words == [
+        "Disney",
+        "Disney",
+        "a",
+        "security",
+        "guard",
+        "the",
+        "security",
+        "guard",
+    ]
+    assert pseudo_doc.head2span == [[0, 0, 1], [1, 1, 2], [4, 2, 5], [7, 5, 8]]
+    assert pseudo_doc.span_clusters == [[(0, 1), (1, 2)], [(2, 5), (5, 8)]]

--- a/coref/test_data_utils.py
+++ b/coref/test_data_utils.py
@@ -3,4 +3,4 @@ from coref.const import Doc
 
 def test_get_doc(dev_data: list[Doc]) -> None:
     assert len(dev_data) == 1
-    assert dev_data[0]["document_id"] == "bc/cctv/00/cctv_0000"
+    assert dev_data[0].document_id == "bc/cctv/00/cctv_0000"

--- a/coref/word_encoder.py
+++ b/coref/word_encoder.py
@@ -50,7 +50,7 @@ class WordEncoder(
             cluster_ids: tensor of shape [n_words], containing cluster indices
                 for each word. Non-coreferent words have cluster id of zero.
         """
-        word_boundaries = torch.tensor(doc["word2subword"], device=self.device)
+        word_boundaries = torch.tensor(doc.word2subword, device=self.device)
         starts = word_boundaries[:, 0]
         ends = word_boundaries[:, 1]
 
@@ -117,14 +117,14 @@ class WordEncoder(
         """
         word2cluster = {
             word_i: i
-            for i, cluster in enumerate(doc["word_clusters"], start=1)
+            for i, cluster in enumerate(doc.word_clusters, start=1)
             for word_i in cluster
         }
 
         return torch.tensor(
             [
                 word2cluster.get(word_i, 0)
-                for word_i in range(len(doc["cased_words"]))
+                for word_i in range(len(doc.cased_words))
             ],
             device=self.device,
         )

--- a/predict.py
+++ b/predict.py
@@ -17,9 +17,9 @@ def build_doc(doc: Doc, model: CorefModel) -> Doc:
     token_map = TOKENIZER_MAPS.get(model.config.model_params.bert_model, {})
 
     word2subword: List[Tuple[int, int]] = []
-    subwords: List[int] = []
+    subwords: List[str] = []
     word_id: List[int] = []
-    for i, word in enumerate(doc["cased_words"]):
+    for i, word in enumerate(doc.cased_words):
         tokenized_word = (
             token_map[word]
             if word in token_map
@@ -31,15 +31,15 @@ def build_doc(doc: Doc, model: CorefModel) -> Doc:
         )
         subwords.extend(tokenized_word)
         word_id.extend([i] * len(tokenized_word))
-    doc["word2subword"] = word2subword
-    doc["subwords"] = subwords
-    doc["word_id"] = word_id
+    doc.word2subword = word2subword
+    doc.subwords = subwords
+    doc.word_id = word_id
 
-    doc["head2span"] = []
-    if "speaker" not in doc:
-        doc["speaker"] = ["_" for _ in doc["cased_words"]]
-    doc["word_clusters"] = []
-    doc["span_clusters"] = []
+    doc.head2span = []
+    if doc.speaker:
+        doc.speaker = ["_" for _ in doc.cased_words]
+    doc.word_clusters = []
+    doc.span_clusters = []
 
     return doc
 


### PR DESCRIPTION
This PR changes the paradigm of sampling. Instead of training the model on docs, the model is trained on spans. 
We sample some spans per document and train the model based on that.

The structure is created on the basis of a `pseudo document`. When training spans are defined, the pipeline creates a `pseudo document` where it retrieves all the metadata for the predefined spans.

The document was changed from a `dict` to a `dataclass`. This will involve new tokenisation (remove old data pickles and the pipeline will automatically create new ones)

Tests are added and the feature is behind a feature flag. This MR is a parent of Mention Sampling PR.

I have fully retrained the coref model and the results are not changed (as expected)