### PR TITLE
Token sampling in the Active Learning loop

### DIFF
--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -41,8 +41,7 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
     sampled_tokens_counter = 0
     counter = 0  # variable to control infinite looping
     sampled_data = SampledData([], [])
-    docs_copy = deepcopy(docs)
-    doc_w_their_position = {doc.orchid_id: i for i, doc in enumerate(docs_copy)}
+    doc_w_their_position = {doc.orchid_id: i for i, doc in enumerate(docs)}
     while sampled_tokens_counter < token_batch:
         # sample the doc and solve the use-cases
         sampled_doc_ids_w_order_id = {
@@ -52,7 +51,7 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
         }
         doc = deepcopy(
             _choose_the_doc_for_token_sampling(
-                docs_copy,
+                docs,
                 sampled_data,
                 sampled_doc_ids_w_order_id,
             )
@@ -86,18 +85,21 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
         if token_in_cluster is None:
             sampled_tokens_counter += 1
             doc.simulation_token_annotations.tokens.add(token)
+            print(token)
         else:
             sampled_tokens_counter += len(token_in_cluster)
             doc.simulation_token_annotations.tokens = (
                 doc.simulation_token_annotations.tokens.union(token_in_cluster)
             )
+            print(token_in_cluster)
 
+        docs[doc_w_their_position[doc.orchid_id]] = deepcopy(doc)
         if doc.orchid_id in sampled_doc_ids_w_order_id:
             sampled_data.instances[
                 sampled_doc_ids_w_order_id[doc.orchid_id]
-            ] = doc.create_simulation_pseudodoc()
+            ] = doc
         else:
-            sampled_data.instances.append(doc.create_simulation_pseudodoc())
+            sampled_data.instances.append(doc)
 
         if counter == 1_000_000:
             raise ValueError("Smth went wrong... The loop got infinite")

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -50,10 +50,12 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
             for i, d in enumerate(sampled_data.instances)
             if d.orchid_id
         }
-        doc = _choose_the_doc_for_token_sampling(
-            docs_copy,
-            sampled_data,
-            sampled_doc_ids_w_order_id,
+        doc = deepcopy(
+            _choose_the_doc_for_token_sampling(
+                docs_copy,
+                sampled_data,
+                sampled_doc_ids_w_order_id,
+            )
         )
         # if no tokens to sample return what we already have
         if doc is None:

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -85,13 +85,11 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
         if token_in_cluster is None:
             sampled_tokens_counter += 1
             doc.simulation_token_annotations.tokens.add(token)
-            print(token)
         else:
             sampled_tokens_counter += len(token_in_cluster)
             doc.simulation_token_annotations.tokens = (
                 doc.simulation_token_annotations.tokens.union(token_in_cluster)
             )
-            print(token_in_cluster)
 
         docs[doc_w_their_position[doc.orchid_id]] = deepcopy(doc)
         if doc.orchid_id in sampled_doc_ids_w_order_id:

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -17,7 +17,7 @@ def random_sampling(instances: list[Doc], batch_size: int) -> SampledData:
 
 
 def token_sampling(
-    docs: list[Doc], token_batch: int, exhaust_doc: bool = False
+    docs: list[Doc], token_batch: int, exhaust_doc: bool = True
 ) -> SampledData:
     """
     The method samples random tokens from docs in the following way:
@@ -84,14 +84,16 @@ def token_sampling(
         token_in_cluster = _get_coref_if_token_in_cluster(
             token, doc.span_clusters
         )
+        doc_tokens_number = len(doc.simulation_token_annotations.tokens)
         if token_in_cluster is None:
-            sampled_tokens_counter += 1
             doc.simulation_token_annotations.tokens.add(token)
         else:
-            sampled_tokens_counter += len(token_in_cluster)
             doc.simulation_token_annotations.tokens = (
                 doc.simulation_token_annotations.tokens.union(token_in_cluster)
             )
+        sampled_tokens_counter += (
+            len(doc.simulation_token_annotations.tokens) - doc_tokens_number
+        )
 
         docs[doc_w_their_position[doc.orchid_id]] = deepcopy(doc)
         if doc.orchid_id in sampled_doc_ids_w_order_id:

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -84,13 +84,13 @@ def token_sampling(
         token_in_cluster = _get_coref_if_token_in_cluster(
             token, doc.span_clusters
         )
-        doc_tokens_number = len(doc.simulation_token_annotations.tokens)
         if token_in_cluster is None:
-            doc.simulation_token_annotations.tokens.add(token)
-        else:
-            doc.simulation_token_annotations.tokens = (
-                doc.simulation_token_annotations.tokens.union(token_in_cluster)
-            )
+            token_in_cluster = {token}
+
+        doc_tokens_number = len(doc.simulation_token_annotations.tokens)
+        doc.simulation_token_annotations.tokens = (
+            doc.simulation_token_annotations.tokens.union(token_in_cluster)
+        )
         sampled_tokens_counter += (
             len(doc.simulation_token_annotations.tokens) - doc_tokens_number
         )

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -171,10 +171,11 @@ def _choose_the_doc_for_token_sampling(
             sampled_doc_ids_w_order_id[doc.orchid_id]
         ].simulation_token_annotations.tokens
     ):
+        new_docs_of_interest = docs_of_interest - 1
         return _choose_the_doc_for_token_sampling(
             [d for i, d in enumerate(docs) if i != doc_id],
             sampled_data,
             sampled_doc_ids_w_order_id,
-            docs_of_interest,
+            new_docs_of_interest if new_docs_of_interest >= 1 else 1,
         )
     return doc

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -1,10 +1,12 @@
-from typing import List
-from random import sample
+from typing import Tuple, Any
+from random import sample, choice
 
-from coref.const import Doc, SampledData
+from coref.const import Doc, SampledData, Optional
+from itertools import chain
+from copy import deepcopy
 
 
-def random_sampling(instances: List[Doc], batch_size: int) -> SampledData:
+def random_sampling(instances: list[Doc], batch_size: int) -> SampledData:
     """
     Provides random sampling from given instances
     """
@@ -13,3 +15,129 @@ def random_sampling(instances: List[Doc], batch_size: int) -> SampledData:
     else:
         indices = sample(list(range(0, len(instances))), batch_size)
     return SampledData(indices, [instances[i] for i in indices])
+
+
+def span_sampling(docs: list[Doc], span_batch: int) -> SampledData:
+    """
+    The method samples random spans from docs in the following way:
+
+    Repeat until # sampled spans equals to the span_batch
+        - Sample a doc
+        - Sample a span
+
+        if a span has antecedents
+            - find the closest one
+        else pass
+
+        if the doc was already sampled before
+            - extend the simulation spans field
+        else
+            - create a pseudo doc and write in simulation spans
+
+    return all created pseudo docs with sampled spans
+    """
+
+    sampled_spans_counter = 0
+    counter = 0  # variable to control infinite looping
+    sampled_data = SampledData([], [])
+    docs_copy = deepcopy(docs)
+    while sampled_spans_counter < span_batch:
+        # sample the doc and solve the use-cases
+        sampled_doc_ids_w_order_id = {
+            d.document_id: i for i, d in enumerate(sampled_data.instances)
+        }
+        doc_w_doc_id = _choose_the_doc_for_span_sampling(
+            docs_copy, sampled_data, sampled_doc_ids_w_order_id
+        )
+        # if no spans to sample return what we already have
+        if doc_w_doc_id is None:
+            return sampled_data
+
+        doc, doc_id = doc_w_doc_id
+        # choose new spans given that we already sampled from the doc
+        if doc.document_id in sampled_doc_ids_w_order_id:
+            sampled_spans = set(
+                sampled_data.instances[
+                    sampled_doc_ids_w_order_id[doc.document_id]
+                ].simulation_span_annotations.spans
+            )
+            docs_copy[doc_id].span_clusters = [
+                [span for span in cluster if span not in sampled_spans]
+                for cluster in doc.span_clusters
+            ]
+        elif len(list(chain.from_iterable(docs_copy[doc_id].span_clusters))) > 0:
+            sampled_data.indices.append(doc_id)
+        else:
+            return sampled_data
+
+        cluster = choice(doc.span_clusters)
+        spans: list[Tuple[int, int]] = []
+        if len(cluster) > 1:
+            # choose the closes coreference
+            spans.extend(choice(_get_consecutive_pairs(cluster)))
+        elif len(cluster) == 1:
+            spans.extend(cluster)
+
+        if cluster:
+            sampled_spans_counter += 1
+            doc.simulation_span_annotations.spans.extend(spans)
+            sampled_data.instances.append(doc.create_simulation_pseudodoc())
+
+        if counter == 1_000_000:
+            raise ValueError("Smth went wrong... The loop got infinite")
+        counter += 1
+        print("*****")
+        print(doc.simulation_span_annotations.spans)
+        print("*")
+        print(docs[doc_id].span_clusters)
+        print("*****")
+    return sampled_data
+
+
+def _get_consecutive_pairs(list_to_pair: list[Any]) -> list[list[Any]]:
+    return [
+        [list_to_pair[i], list_to_pair[i + 1]] for i in range(len(list_to_pair) - 1)
+    ]
+
+
+def _choose_the_doc_for_span_sampling(
+    docs: list[Doc],
+    sampled_data: SampledData,
+    sampled_doc_ids_w_order_id: dict[str, int],
+) -> Optional[Tuple[Doc, int]]:
+    """
+    docs: list of Docs to sample from
+    sampled_data: the docs that the spans were already sampled from
+    sampled_doc_ids_w_order_id: mapping of sampled doc ids to their
+    order in the SampleData instances list
+
+    Returns doc and its id in the docs list
+
+    Edge cases:
+        - If all spans were sampled from the doc, returns None
+    """
+    if not docs:
+        return None
+    doc_id = choice(range(len(docs)))
+    doc = docs[doc_id]
+    if doc.document_id in sampled_doc_ids_w_order_id and (
+        len(set(chain.from_iterable(doc.span_clusters)))
+        == len(
+            set(
+                chain.from_iterable(
+                    sampled_data.instances[
+                        sampled_doc_ids_w_order_id[doc.document_id]
+                    ].simulation_span_annotations.spans
+                )
+            )
+        )
+    ):
+        return _choose_the_doc_for_span_sampling(
+            [d for i, d in enumerate(docs) if i != doc_id],
+            sampled_data,
+            sampled_doc_ids_w_order_id,
+        )
+    return doc, doc_id
+
+
+I sample from a wrong field! I have to sample for spans field and then take the cluster info if I get to a cluster span

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -16,12 +16,17 @@ def random_sampling(instances: list[Doc], batch_size: int) -> SampledData:
     return SampledData(indices, [instances[i] for i in indices])
 
 
-def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
+def token_sampling(
+    docs: list[Doc], token_batch: int, exhaust_doc: bool = False
+) -> SampledData:
     """
     The method samples random tokens from docs in the following way:
 
     Repeat until # sampled tokens equals to the token_batch
-        - Sample a doc
+        - Sample a doc (
+            if exhaust_doc == True, then tokens will be
+            sampled till the doc is fully exhausted of tokens
+        )
         - Sample a token
 
         if a token belongs to a coreference span and has other mentions
@@ -50,9 +55,7 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
         }
         doc = deepcopy(
             _choose_the_doc_for_token_sampling(
-                docs,
-                sampled_data,
-                sampled_doc_ids_w_order_id,
+                docs, sampled_data, sampled_doc_ids_w_order_id, exhaust_doc
             )
         )
         # if no tokens to sample return what we already have
@@ -137,12 +140,14 @@ def _choose_the_doc_for_token_sampling(
     docs: list[Doc],
     sampled_data: SampledData,
     sampled_doc_ids_w_order_id: dict[str, int],
+    exhaust_doc: bool,
 ) -> Optional[Doc]:
     """
     docs: list of Docs to sample from
     sampled_data: the docs that the tokens were already sampled from
     sampled_doc_ids_w_order_id: mapping of sampled doc ids to their
     order in the SampleData instances list
+    exhaust_doc: strategy to always sample the first doc
 
     Returns doc and its id in the docs list
 
@@ -151,7 +156,7 @@ def _choose_the_doc_for_token_sampling(
     """
     if not docs:
         return None
-    doc_id = choice(range(len(docs)))
+    doc_id = choice(range(len(docs))) if not exhaust_doc else 0
     doc = docs[doc_id]
     if doc.orchid_id in sampled_doc_ids_w_order_id and (
         set(range(len(doc.cased_words)))
@@ -163,5 +168,6 @@ def _choose_the_doc_for_token_sampling(
             [d for i, d in enumerate(docs) if i != doc_id],
             sampled_data,
             sampled_doc_ids_w_order_id,
+            exhaust_doc,
         )
     return doc

--- a/active_learning/acquisition_functions.py
+++ b/active_learning/acquisition_functions.py
@@ -1,8 +1,7 @@
-from typing import Tuple, Any
+from typing import Tuple
 from random import sample, choice
 
 from coref.const import Doc, SampledData, Optional
-from itertools import chain
 from copy import deepcopy
 
 
@@ -31,11 +30,11 @@ def token_sampling(docs: list[Doc], token_batch: int) -> SampledData:
             - take the token as it is
 
         if the doc was already sampled before
-            - extend the simulation tokens field and create a new pseudo doc
+            - extend the simulation tokens field and save a doc
         else
-            - create a pseudo doc and write in simulation tokens
+            - save a doc and write in simulation tokens
 
-    return all created pseudo docs with sampled tokens
+    return all created docs with sampled tokens
     """
 
     sampled_tokens_counter = 0

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -47,7 +47,7 @@ def get_logging_info(
 
 
 def run_simulation(
-    model: GeneralCorefModel,
+    model: GeneralCorefModel,  # unused for now
     config: Config,
     train_docs: list[Doc],
     test_data: list[Doc],
@@ -56,15 +56,7 @@ def run_simulation(
 
     al_config = config.active_learning
 
-    training_data, train_docs = train_split(model, train_docs)
-    get_logging_info(model, training_data, round=0)
-    run_training(
-        model, training_data, dev_docs, test_data
-    )  # First (zeroth) training
-
-    model._logger.info("Initial training iteration is done...\n")
-
-    for i in range(al_config.simulation.active_learning_steps):
+    for i in range(al_config.sampling_strategy.total_number_of_iterations):
         model = load_coref_model(config)
 
         training_data, train_docs = train_split(model, train_docs)

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -15,6 +15,7 @@ def get_training_iteration_docs(
         doc.create_simulation_pseudodoc()
         for i, doc in enumerate(docs)
         if i not in sampled_docs.indices
+        and doc.simulation_token_annotations.tokens
     ]
 
 

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -2,14 +2,18 @@ from coref.models import GeneralCorefModel
 from coref.const import Doc, SampledData
 from coref.models import load_coref_model, GeneralCorefModel
 from config import Config
+from typing import Tuple
+from copy import deepcopy
 
 
 def get_training_iteration_docs(
     docs: list[Doc], sampled_docs: SampledData
-) -> list[Doc]:
+) -> Tuple[list[Doc], list[Doc]]:
     for i, doc in zip(sampled_docs.indices, sampled_docs.instances):
         docs[i].simulation_token_annotations = doc.simulation_token_annotations
-    return [doc for doc in docs if doc.simulation_token_annotations.tokens]
+    return [
+        doc for doc in docs if doc.simulation_token_annotations.tokens
+    ], docs
 
 
 def run_simulation(
@@ -23,7 +27,9 @@ def run_simulation(
     al_config = config.active_learning
     # Training split
     sampled_data = model.sample_unlabled_data(train_docs)
-    training_data = get_training_iteration_docs(train_docs, sampled_data)
+    training_data, train_docs = get_training_iteration_docs(
+        deepcopy(train_docs), sampled_data
+    )
 
     # First training
     model.train(docs=training_data, docs_dev=dev_docs)
@@ -35,7 +41,9 @@ def run_simulation(
         model._logger.info(f" AL SIMULATION | round: {i}\n")
         # Prepare the data
         sampled_data = model.sample_unlabled_data(train_docs)
-        training_data = get_training_iteration_docs(train_docs, sampled_data)
+        training_data, train_docs = get_training_iteration_docs(
+            deepcopy(train_docs), sampled_data
+        )
 
         # Train the model
         model = load_coref_model(config)

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -12,7 +12,7 @@ def get_training_iteration_docs(
             i
         ].simulation_token_annotations = pseudo_doc.simulation_token_annotations
     return sampled_docs.instances + [
-        doc.create_simulation_pseudodoc()
+        doc
         for i, doc in enumerate(docs)
         if i not in sampled_docs.indices
         and doc.simulation_token_annotations.tokens

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -4,6 +4,7 @@ from coref.models import load_coref_model, GeneralCorefModel
 from config import Config
 from typing import Tuple
 from copy import deepcopy
+from random import shuffle
 
 
 def get_training_iteration_docs(
@@ -19,6 +20,7 @@ def get_training_iteration_docs(
 def train_split(
     model: GeneralCorefModel, train_docs: list[Doc]
 ) -> Tuple[list[Doc], list[Doc]]:
+    shuffle(train_docs)
     sampled_data = model.sample_unlabled_data(train_docs)
     return get_training_iteration_docs(deepcopy(train_docs), sampled_data)
 

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -30,6 +30,12 @@ def run_simulation(
     training_data, train_docs = get_training_iteration_docs(
         deepcopy(train_docs), sampled_data
     )
+    tokens = sum(
+        len(doc.simulation_token_annotations.tokens) for doc in training_data
+    )
+    model._logger.info(
+        f" AL SIMULATION | round: 0, Documents: {len(training_data)}, Tokens: {tokens}\n"
+    )
 
     # First training
     model.train(docs=training_data, docs_dev=dev_docs)
@@ -38,11 +44,18 @@ def run_simulation(
     model._logger.info("Yo Yo! Initial training iteration is done...\n")
 
     for i in range(al_config.simulation.active_learning_steps):
-        model._logger.info(f" AL SIMULATION | round: {i}\n")
         # Prepare the data
         sampled_data = model.sample_unlabled_data(train_docs)
         training_data, train_docs = get_training_iteration_docs(
             deepcopy(train_docs), sampled_data
+        )
+
+        tokens = sum(
+            len(doc.simulation_token_annotations.tokens)
+            for doc in training_data
+        )
+        model._logger.info(
+            f" AL SIMULATION | round: {i+1}, Documents: {len(training_data)}, Tokens: {tokens}\n"
         )
 
         # Train the model

--- a/active_learning/active_learning_simulation.py
+++ b/active_learning/active_learning_simulation.py
@@ -7,16 +7,9 @@ from config import Config
 def get_training_iteration_docs(
     docs: list[Doc], sampled_docs: SampledData
 ) -> list[Doc]:
-    for i, pseudo_doc in zip(sampled_docs.indices, sampled_docs.instances):
-        docs[
-            i
-        ].simulation_token_annotations = pseudo_doc.simulation_token_annotations
-    return sampled_docs.instances + [
-        doc
-        for i, doc in enumerate(docs)
-        if i not in sampled_docs.indices
-        and doc.simulation_token_annotations.tokens
-    ]
+    for i, doc in zip(sampled_docs.indices, sampled_docs.instances):
+        docs[i].simulation_token_annotations = doc.simulation_token_annotations
+    return [doc for doc in docs if doc.simulation_token_annotations.tokens]
 
 
 def run_simulation(

--- a/active_learning/exploration.py
+++ b/active_learning/exploration.py
@@ -16,7 +16,7 @@ class AcquisitionFunctionsType(Enum):
     random = "random"
 
 
-acquisition_func_typing = Callable[[List[Doc], int, bool], SampledData]
+acquisition_func_typing = Callable[[List[Doc], int, int], SampledData]
 
 
 ACQUISITION_FUNCTION_MAPPER: Dict[
@@ -40,8 +40,8 @@ class GreedySampling:
     args:
         acquisition_function_type - the function name to sample new data
 
-        exhaust_document - strategy flag which allows to samples all tokens from a document,
-        given the batch size. ( TODO Will not be binary in future iterations )
+        docs_of_interest - strategy which prioritizes taking tokens from 0th to docs_of_interest-th
+        idex, given the batch size
 
         batch_size - Batch size to sample
 
@@ -53,7 +53,7 @@ class GreedySampling:
     """
 
     acquisition_function_type: AcquisitionFunctionsType
-    exhaust_document: bool
+    docs_of_interest: int
     batch_size: int
     strategy_flip: float
     total_number_of_iterations: int
@@ -92,10 +92,10 @@ class GreedySampling:
         self.epsilon_greedy_prob = 1 - self.sigmoid()
         if random() <= self.epsilon_greedy_prob:
             return token_sampling(
-                instances, self.batch_size, self.exhaust_document
+                instances, self.batch_size, self.docs_of_interest
             )
         return self.acquisition_function(
-            instances, self.batch_size, self.exhaust_document
+            instances, self.batch_size, self.docs_of_interest
         )
 
     def sigmoid(self) -> float:
@@ -110,14 +110,14 @@ class GreedySampling:
     @staticmethod
     def load_config(
         acquisition_function_type: str,
-        exhaust_document: bool,
+        docs_of_interest: int,
         batch_size: int,
         strategy_flip: float,
         total_number_of_iterations: int,
     ) -> "GreedySampling":
         return GreedySampling(
             AcquisitionFunctionsType(acquisition_function_type),
-            exhaust_document,
+            docs_of_interest,
             batch_size,
             strategy_flip,
             total_number_of_iterations,

--- a/active_learning/exploration.py
+++ b/active_learning/exploration.py
@@ -7,7 +7,7 @@ from random import random
 
 from coref.const import Doc, SampledData
 from active_learning.acquisition_functions import (
-    random_sampling,
+    # random_sampling,
     token_sampling,
 )
 
@@ -16,8 +16,11 @@ class AcquisitionFunctionsType(Enum):
     random = "random"
 
 
+acquisition_func_typing = Callable[[List[Doc], int, bool], SampledData]
+
+
 ACQUISITION_FUNCTION_MAPPER: Dict[
-    AcquisitionFunctionsType, Callable[[List[Doc], int], SampledData]
+    AcquisitionFunctionsType, acquisition_func_typing
 ] = {AcquisitionFunctionsType.random: token_sampling}
 
 
@@ -37,6 +40,9 @@ class GreedySampling:
     args:
         acquisition_function_type - the function name to sample new data
 
+        exhaust_document - strategy flag which allows to samples all tokens from a document,
+        given the batch size. ( TODO Will not be binary in future iterations )
+
         batch_size - Batch size to sample
 
         strategy_flip - Prob[random_strategy|current_sampling_iteration/total_number_of_iterations] = 0.5
@@ -47,12 +53,11 @@ class GreedySampling:
     """
 
     acquisition_function_type: AcquisitionFunctionsType
+    exhaust_document: bool
     batch_size: int
     strategy_flip: float
     total_number_of_iterations: int
-    acquisition_function: Callable[[List[Doc], int], SampledData] = field(
-        init=False
-    )
+    acquisition_function: acquisition_func_typing = field(init=False)
     epsilon_greedy_prob: float = field(init=False)
     current_sampling_iteration: int = field(init=False)
     flip_iteration: int = field(init=False)
@@ -86,8 +91,12 @@ class GreedySampling:
         self.current_sampling_iteration += 1
         self.epsilon_greedy_prob = 1 - self.sigmoid()
         if random() <= self.epsilon_greedy_prob:
-            return token_sampling(instances, self.batch_size)
-        return self.acquisition_function(instances, self.batch_size)
+            return token_sampling(
+                instances, self.batch_size, self.exhaust_document
+            )
+        return self.acquisition_function(
+            instances, self.batch_size, self.exhaust_document
+        )
 
     def sigmoid(self) -> float:
         return 1 / (
@@ -101,12 +110,14 @@ class GreedySampling:
     @staticmethod
     def load_config(
         acquisition_function_type: str,
+        exhaust_document: bool,
         batch_size: int,
         strategy_flip: float,
         total_number_of_iterations: int,
     ) -> "GreedySampling":
         return GreedySampling(
             AcquisitionFunctionsType(acquisition_function_type),
+            exhaust_document,
             batch_size,
             strategy_flip,
             total_number_of_iterations,

--- a/active_learning/exploration.py
+++ b/active_learning/exploration.py
@@ -6,8 +6,10 @@ from typing import Callable, Dict, List
 from random import random
 
 from coref.const import Doc, SampledData
-from active_learning.acquisition_functions import random_sampling
-from config.config_utils import overwrite_config
+from active_learning.acquisition_functions import (
+    random_sampling,
+    token_sampling,
+)
 
 
 class AcquisitionFunctionsType(Enum):
@@ -16,7 +18,7 @@ class AcquisitionFunctionsType(Enum):
 
 ACQUISITION_FUNCTION_MAPPER: Dict[
     AcquisitionFunctionsType, Callable[[List[Doc], int], SampledData]
-] = {AcquisitionFunctionsType.random: random_sampling}
+] = {AcquisitionFunctionsType.random: token_sampling}
 
 
 @dataclass
@@ -84,7 +86,7 @@ class GreedySampling:
         self.current_sampling_iteration += 1
         self.epsilon_greedy_prob = 1 - self.sigmoid()
         if random() <= self.epsilon_greedy_prob:
-            return random_sampling(instances, self.batch_size)
+            return token_sampling(instances, self.batch_size)
         return self.acquisition_function(instances, self.batch_size)
 
     def sigmoid(self) -> float:

--- a/active_learning/test_acquisition_functions.py
+++ b/active_learning/test_acquisition_functions.py
@@ -1,5 +1,6 @@
 from coref.const import Doc
-from active_learning.acquisition_functions import random_sampling
+from active_learning.acquisition_functions import random_sampling, span_sampling
+from itertools import chain
 
 BATCH_SIZE = 7
 TOO_LARGE_BATCH_SIZE = 11
@@ -16,3 +17,18 @@ def test_random_sampling_w_too_large_batch_size(dev_data: list[Doc]) -> None:
     sampled_data = random_sampling(dev_data, TOO_LARGE_BATCH_SIZE)
     assert len(sampled_data.indices) == len(dev_data)
     assert sampled_data.instances[0].document_id == "bc/cctv/00/cctv_0000"
+
+
+def test_span_sampling(dev_data: list[Doc]) -> None:
+    assert (
+        len(
+            span_sampling(dev_data, BATCH_SIZE)
+            .instances[0]
+            .simulation_span_annotations.spans
+        )
+        >= BATCH_SIZE
+    )
+
+    assert len(
+        span_sampling(dev_data, 23).instances[0].simulation_span_annotations.spans
+    ) == len(set(chain.from_iterable(dev_data[0].span_clusters)))

--- a/active_learning/test_acquisition_functions.py
+++ b/active_learning/test_acquisition_functions.py
@@ -1,6 +1,9 @@
 from coref.const import Doc
-from active_learning.acquisition_functions import random_sampling, span_sampling
-from itertools import chain
+from active_learning.acquisition_functions import (
+    random_sampling,
+    token_sampling,
+)
+from copy import deepcopy
 
 BATCH_SIZE = 7
 TOO_LARGE_BATCH_SIZE = 11
@@ -19,16 +22,44 @@ def test_random_sampling_w_too_large_batch_size(dev_data: list[Doc]) -> None:
     assert sampled_data.instances[0].document_id == "bc/cctv/00/cctv_0000"
 
 
-def test_span_sampling(dev_data: list[Doc]) -> None:
+def test_token_sampling(dev_data: list[Doc]) -> None:
+    # if we some batch size, we will sample at least
+    # the amount we want to sample due to the possible spans
     assert (
         len(
-            span_sampling(dev_data, BATCH_SIZE)
+            token_sampling(dev_data, BATCH_SIZE)
             .instances[0]
-            .simulation_span_annotations.spans
+            .simulation_token_annotations.tokens
         )
         >= BATCH_SIZE
     )
 
+    # if ask to sample more that we have in docs we will get all
+    # tokens from all docs
     assert len(
-        span_sampling(dev_data, 23).instances[0].simulation_span_annotations.spans
-    ) == len(set(chain.from_iterable(dev_data[0].span_clusters)))
+        token_sampling(dev_data, 1_000_000)
+        .instances[0]
+        .simulation_token_annotations.tokens
+    ) == len(dev_data[0].cased_words)
+
+    # Test multiple docs
+    new_docs = [
+        deepcopy(dev_data[0]),
+        deepcopy(dev_data[0]),
+        deepcopy(dev_data[0]),
+    ]
+    new_docs[0].orchid_id = "id_0"
+    new_docs[1].orchid_id = "id_1"
+    new_docs[2].orchid_id = "id_3"
+
+    sampled_tokens = token_sampling(new_docs, 1_000_000)
+
+    assert len(
+        sampled_tokens.instances[0].simulation_token_annotations.tokens
+    ) == len(new_docs[sampled_tokens.indices[0]].cased_words)
+    assert len(
+        sampled_tokens.instances[1].simulation_token_annotations.tokens
+    ) == len(new_docs[sampled_tokens.indices[1]].cased_words)
+    assert len(
+        sampled_tokens.instances[2].simulation_token_annotations.tokens
+    ) == len(new_docs[sampled_tokens.indices[2]].cased_words)

--- a/active_learning/test_acquisition_functions.py
+++ b/active_learning/test_acquisition_functions.py
@@ -27,7 +27,7 @@ def test_token_sampling(dev_data: list[Doc]) -> None:
     # the amount we want to sample due to the possible spans
     assert (
         len(
-            token_sampling(dev_data, BATCH_SIZE)
+            token_sampling(dev_data, BATCH_SIZE, 100_000)
             .instances[0]
             .simulation_token_annotations.tokens
         )
@@ -37,7 +37,7 @@ def test_token_sampling(dev_data: list[Doc]) -> None:
     # if ask to sample more that we have in docs we will get all
     # tokens from all docs
     assert len(
-        token_sampling(dev_data, 1_000_000)
+        token_sampling(dev_data, 1_000_000, 100_000)
         .instances[0]
         .simulation_token_annotations.tokens
     ) == len(dev_data[0].cased_words)
@@ -52,7 +52,7 @@ def test_token_sampling(dev_data: list[Doc]) -> None:
     new_docs[1].orchid_id = "id_1"
     new_docs[2].orchid_id = "id_3"
 
-    sampled_tokens = token_sampling(new_docs, 1_000_000)
+    sampled_tokens = token_sampling(new_docs, 1_000_000, 100_000)
 
     assert len(
         sampled_tokens.instances[0].simulation_token_annotations.tokens

--- a/config.toml
+++ b/config.toml
@@ -262,5 +262,10 @@
 [active_learning_simulation]
     [active_learning_simulation.model_params]
         bert_model = "roberta-large"
-[active_learning_simulation.active_learning]
+    [active_learning_simulation.active_learning]
         token_sampling = true
+        [active_learning_simulation.active_learning.simulation]
+            initial_sample_size = 5000
+            active_learning_steps = 10
+    [active_learning_simulation.training_params]
+        train_epochs = 20

--- a/config.toml
+++ b/config.toml
@@ -264,8 +264,8 @@
         bert_model = "roberta-large"
     [active_learning_simulation.active_learning]
         token_sampling = true
-        [active_learning_simulation.active_learning.sampling_strategy]
-            initial_sample_size = 5000
-            active_learning_steps = 10
+    [active_learning_simulation.active_learning.sampling_strategy]
+        initial_sample_size = 5000
+        active_learning_steps = 10
     [active_learning_simulation.training_params]
         train_epochs = 2

--- a/config.toml
+++ b/config.toml
@@ -140,8 +140,8 @@
             # the total number of planned samplings
             total_number_of_iterations = 10
 
-            # Prioritize taking all possible tokens from a document, given the batch size
-            exhaust_document = false
+            # Prioritize taking tokens from 0th to docs_of_interest-th idex, given the batch size
+            docs_of_interest = 100
 
     [DEFAULT.manifold_learning]
         enable = true
@@ -269,7 +269,7 @@
         token_sampling = true
     [active_learning_simulation.active_learning.sampling_strategy]
         batch_size = 5000
-        exhaust_document = false
+        docs_of_interest = 100
         total_number_of_iterations = 10
     [active_learning_simulation.training_params]
         train_epochs = 2

--- a/config.toml
+++ b/config.toml
@@ -140,6 +140,9 @@
             # the total number of planned samplings
             total_number_of_iterations = 10
 
+            # Prioritize taking all possible tokens from a document, given the batch size
+            exhaust_document = false
+
     [DEFAULT.manifold_learning]
         enable = true
         # Manifold Learning parameters
@@ -266,6 +269,7 @@
         token_sampling = true
     [active_learning_simulation.active_learning.sampling_strategy]
         batch_size = 5000
+        exhaust_document = false
         total_number_of_iterations = 10
     [active_learning_simulation.training_params]
         train_epochs = 2

--- a/config.toml
+++ b/config.toml
@@ -111,7 +111,7 @@
         parameters_samples = 10
 
         # Turn on span sampling instead of documents sampling
-        span_sampling = false
+        token_sampling = false
 
         [DEFAULT.active_learning.simulation]
             # Simulation parameters (e.g. starting sample size, number of iterations, ...)
@@ -235,7 +235,7 @@
     [debug.logging]
         logger_name = "test_run"
     [debug.active_learning]
-        span_sampling = true
+        token_sampling = true
 
 
 [mc_dropout]
@@ -263,4 +263,4 @@
     [active_learning_simulation.model_params]
         bert_model = "roberta-large"
 [active_learning_simulation.active_learning]
-        span_sampling = true
+        token_sampling = true

--- a/config.toml
+++ b/config.toml
@@ -265,7 +265,7 @@
     [active_learning_simulation.active_learning]
         token_sampling = true
     [active_learning_simulation.active_learning.sampling_strategy]
-        initial_sample_size = 5000
-        active_learning_steps = 10
+        batch_size = 5000
+        total_number_of_iterations = 10
     [active_learning_simulation.training_params]
         train_epochs = 2

--- a/config.toml
+++ b/config.toml
@@ -120,7 +120,7 @@
             initial_sample_size = 100
 
             # Active learning steps to perform
-            active_learning_steps = 5
+            active_learning_loops = 5
 
 
         [DEFAULT.active_learning.sampling_strategy]

--- a/config.toml
+++ b/config.toml
@@ -264,8 +264,8 @@
         bert_model = "roberta-large"
     [active_learning_simulation.active_learning]
         token_sampling = true
-        [active_learning_simulation.active_learning.simulation]
+        [active_learning_simulation.active_learning.sampling_strategy]
             initial_sample_size = 5000
             active_learning_steps = 10
     [active_learning_simulation.training_params]
-        train_epochs = 20
+        train_epochs = 2

--- a/config/active_learning.py
+++ b/config/active_learning.py
@@ -15,8 +15,8 @@ class Simulation:
 
 @dataclass
 class ActiveLearning:
-    # Span sampling instead of documents sampling
-    span_sampling: bool
+    # Token sampling instead of documents sampling
+    token_sampling: bool
     # Active Learning parameters
     parameters_samples: int
     # Active Learning sampling strategy.
@@ -27,13 +27,13 @@ class ActiveLearning:
     @staticmethod
     @overwrite_config
     def load_config(
-        span_sampling: bool,
+        token_sampling: bool,
         parameters_samples: int,
         sampling_strategy: dict[str, Any],
         simulation: dict[str, Any],
     ) -> "ActiveLearning":
         return ActiveLearning(
-            span_sampling,
+            token_sampling,
             parameters_samples,
             GreedySampling.load_config(**sampling_strategy),
             Simulation(**simulation),

--- a/config/active_learning.py
+++ b/config/active_learning.py
@@ -9,8 +9,8 @@ from typing import Dict, Any
 class Simulation:
     # Number of instances used for the first training iteration
     initial_sample_size: int
-    # Active learning steps to perform
-    active_learning_steps: int
+    # Active learning loops to perform
+    active_learning_loops: int
 
 
 @dataclass

--- a/coref/const.py
+++ b/coref/const.py
@@ -1,6 +1,6 @@
 """ Contains type aliases for coref module """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Tuple, Optional
 import hashlib
 

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -90,7 +90,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         self.sampling_strategy: GreedySampling = (
             config.active_learning.sampling_strategy
         )
-        self._logger.info("Initialization of the general coreference model is complete")
+        self._logger.info(
+            "Initialization of the general coreference model is complete"
+        )
 
     @property
     def training(self) -> bool:
@@ -147,7 +149,10 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                     pred_starts = res.span_scores[:, :, 0].argmax(dim=1)
                     pred_ends = res.span_scores[:, :, 1].argmax(dim=1)
                     s_correct += (
-                        ((res.span_y[0] == pred_starts) * (res.span_y[1] == pred_ends))
+                        (
+                            (res.span_y[0] == pred_starts)
+                            * (res.span_y[1] == pred_ends)
+                        )
                         .sum()
                         .item()
                     )
@@ -155,7 +160,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
                 if word_level_conll:
                     if res.word_clusters is None:
-                        raise RuntimeError(f'"word_clusters" attribute must be set')
+                        raise RuntimeError(
+                            f'"word_clusters" attribute must be set'
+                        )
                     conll.write_conll(
                         doc,
                         [
@@ -175,7 +182,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 else:
                     conll.write_conll(doc, doc.span_clusters, gold_f)
                     if res.span_clusters is None:
-                        raise RuntimeError(f'"span_clusters" attribute must be set')
+                        raise RuntimeError(
+                            f'"span_clusters" attribute must be set'
+                        )
                     conll.write_conll(doc, res.span_clusters, pred_f)
 
                 w_checker.add_predictions(
@@ -243,7 +252,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 if noexception:
                     self._logger.info("No weights have been loaded")
                     return
-                raise OSError(f"No weights found in {self.config.data.data_dir}!")
+                raise OSError(
+                    f"No weights found in {self.config.data.data_dir}!"
+                )
             _, path = sorted(files)[-1]
             path = os.path.join(self.config.data.data_dir, path)
 
@@ -283,15 +294,15 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         # Encode words with bert
         encoded_doc = self._bertify(doc)
 
-        # If span_sampling is on, then rewrite the doc to a pseudo doc. This will use
-        # only spans, given in the simulation_span_annotations field. If the field
-        # is empty, the method will use all available annotated spans.
+        # If token_sampling is on, then rewrite the doc to a pseudo doc. This will use
+        # only tokens, given in the simulation_token_annotations field. If the field
+        # is empty, the method will use all available annotated tokens.
         # N.B. The quality of encoding is not damaged because it is done on the whole
         # article
-        if self.config.active_learning.span_sampling:
+        if self.config.active_learning.token_sampling:
             doc = doc.create_simulation_pseudodoc()
             encoded_doc = encoded_doc[
-                doc.simulation_span_annotations.original_subtokens_ids, :
+                doc.simulation_token_annotations.original_subtokens_ids, :
             ]
 
         # words           [n_words, span_emb]
@@ -365,7 +376,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         savedict["epochs_trained"] = self.epochs_trained  # type: ignore
         torch.save(savedict, path)
 
-    def train(self, docs: List[Doc], docs_dev: Optional[List[Doc]] = None) -> None:
+    def train(
+        self, docs: List[Doc], docs_dev: Optional[List[Doc]] = None
+    ) -> None:
         """
         Trains all the trainable blocks in the model using the config provided.
         """
@@ -445,7 +458,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             )
             metrics_vals.append(pavpu_output)
 
-        metrics_val: list[float] = np.mean(np.array(metrics_vals), axis=0).tolist()
+        metrics_val: list[float] = np.mean(
+            np.array(metrics_vals), axis=0
+        ).tolist()
 
         self._logger.info(f"PAVPU METRICS | avg_pavpu: {metrics_val}")
 
@@ -491,7 +506,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
     def _build_model(self) -> None:
         self.bert = self.config.model_bank.encoder
         self.tokenizer = self.config.model_bank.tokenizer
-        self.pw = PairwiseEncoder(self.config).to(self.config.training_params.device)
+        self.pw = PairwiseEncoder(self.config).to(
+            self.config.training_params.device
+        )
 
         bert_emb = self.bert.config.hidden_size
         pair_emb = bert_emb * 3 + self.pw.shape
@@ -520,7 +537,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         }
 
     def _build_criteria(self) -> None:
-        self._coref_criterion = CorefLoss(self.config.training_params.bce_loss_weight)
+        self._coref_criterion = CorefLoss(
+            self.config.training_params.bce_loss_weight
+        )
         self._span_criterion = torch.nn.CrossEntropyLoss(reduction="sum")
 
     def _build_optimizers(self) -> None:
@@ -550,7 +569,9 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
         # Must ensure the same ordering of parameters between launches
         modules = sorted(
-            (key, value) for key, value in self.trainable.items() if key != "bert"
+            (key, value)
+            for key, value in self.trainable.items()
+            if key != "bert"
         )
         params = []
         for _, module in modules:

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -301,14 +301,10 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         # N.B. The quality of encoding is not damaged because it is done on the whole
         # article
         if self.config.active_learning.token_sampling:
-            pseudo_doc = doc.create_simulation_pseudodoc()
-            del doc
-            doc = pseudo_doc
-            pseudo_encoded_doc = encoded_doc[
+            doc = doc.create_simulation_pseudodoc()
+            encoded_doc = encoded_doc[
                 doc.simulation_token_annotations.original_subtokens_ids, :
             ]
-            del encoded_doc
-            encoded_doc = pseudo_encoded_doc
 
         # words           [n_words, span_emb]
         # cluster_ids     [n_words]

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -90,9 +90,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         self.sampling_strategy: GreedySampling = (
             config.active_learning.sampling_strategy
         )
-        self._logger.info(
-            "Initialization of the general coreference model is complete"
-        )
+        self._logger.info("Initialization of the general coreference model is complete")
 
     @property
     def training(self) -> bool:
@@ -149,10 +147,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                     pred_starts = res.span_scores[:, :, 0].argmax(dim=1)
                     pred_ends = res.span_scores[:, :, 1].argmax(dim=1)
                     s_correct += (
-                        (
-                            (res.span_y[0] == pred_starts)
-                            * (res.span_y[1] == pred_ends)
-                        )
+                        ((res.span_y[0] == pred_starts) * (res.span_y[1] == pred_ends))
                         .sum()
                         .item()
                     )
@@ -160,9 +155,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
                 if word_level_conll:
                     if res.word_clusters is None:
-                        raise RuntimeError(
-                            f'"word_clusters" attribute must be set'
-                        )
+                        raise RuntimeError(f'"word_clusters" attribute must be set')
                     conll.write_conll(
                         doc,
                         [
@@ -182,9 +175,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 else:
                     conll.write_conll(doc, doc.span_clusters, gold_f)
                     if res.span_clusters is None:
-                        raise RuntimeError(
-                            f'"span_clusters" attribute must be set'
-                        )
+                        raise RuntimeError(f'"span_clusters" attribute must be set')
                     conll.write_conll(doc, res.span_clusters, pred_f)
 
                 w_checker.add_predictions(
@@ -252,9 +243,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 if noexception:
                     self._logger.info("No weights have been loaded")
                     return
-                raise OSError(
-                    f"No weights found in {self.config.data.data_dir}!"
-                )
+                raise OSError(f"No weights found in {self.config.data.data_dir}!")
             _, path = sorted(files)[-1]
             path = os.path.join(self.config.data.data_dir, path)
 
@@ -291,15 +280,14 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             CorefResult (see const.py)
         """
 
-        # Rewrite the doc to a pseudo doc. This will use only spans, given in
-        # the simulation_span_annotations field. If the field is empty, the method
-        # will use all available annotated spans.
-        # N.B. The quality of encoding is not damaged because it is done on the whole
-        # article
-
         # Encode words with bert
         encoded_doc = self._bertify(doc)
 
+        # If span_sampling is on, then rewrite the doc to a pseudo doc. This will use
+        # only spans, given in the simulation_span_annotations field. If the field
+        # is empty, the method will use all available annotated spans.
+        # N.B. The quality of encoding is not damaged because it is done on the whole
+        # article
         if self.config.active_learning.span_sampling:
             doc = doc.create_simulation_pseudodoc()
             encoded_doc = encoded_doc[
@@ -377,9 +365,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         savedict["epochs_trained"] = self.epochs_trained  # type: ignore
         torch.save(savedict, path)
 
-    def train(
-        self, docs: List[Doc], docs_dev: Optional[List[Doc]] = None
-    ) -> None:
+    def train(self, docs: List[Doc], docs_dev: Optional[List[Doc]] = None) -> None:
         """
         Trains all the trainable blocks in the model using the config provided.
         """
@@ -459,9 +445,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             )
             metrics_vals.append(pavpu_output)
 
-        metrics_val: list[float] = np.mean(
-            np.array(metrics_vals), axis=0
-        ).tolist()
+        metrics_val: list[float] = np.mean(np.array(metrics_vals), axis=0).tolist()
 
         self._logger.info(f"PAVPU METRICS | avg_pavpu: {metrics_val}")
 
@@ -507,9 +491,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
     def _build_model(self) -> None:
         self.bert = self.config.model_bank.encoder
         self.tokenizer = self.config.model_bank.tokenizer
-        self.pw = PairwiseEncoder(self.config).to(
-            self.config.training_params.device
-        )
+        self.pw = PairwiseEncoder(self.config).to(self.config.training_params.device)
 
         bert_emb = self.bert.config.hidden_size
         pair_emb = bert_emb * 3 + self.pw.shape
@@ -538,9 +520,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         }
 
     def _build_criteria(self) -> None:
-        self._coref_criterion = CorefLoss(
-            self.config.training_params.bce_loss_weight
-        )
+        self._coref_criterion = CorefLoss(self.config.training_params.bce_loss_weight)
         self._span_criterion = torch.nn.CrossEntropyLoss(reduction="sum")
 
     def _build_optimizers(self) -> None:
@@ -570,9 +550,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
         # Must ensure the same ordering of parameters between launches
         modules = sorted(
-            (key, value)
-            for key, value in self.trainable.items()
-            if key != "bert"
+            (key, value) for key, value in self.trainable.items() if key != "bert"
         )
         params = []
         for _, module in modules:

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -14,6 +14,7 @@ from typing import (
     TYPE_CHECKING,
     TypeVar,
 )
+from copy import deepcopy
 
 import numpy as np  # type: ignore
 import torch
@@ -135,7 +136,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         ):
             pbar = tqdm(docs, unit="docs", ncols=0)
             for doc in pbar:
-                res = self.run(doc, True)
+                res = self.run(deepcopy(doc), True)
 
                 running_loss += self._coref_criterion(
                     res.coref_scores, res.coref_y
@@ -399,7 +400,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 for optim in self.optimizers.values():
                     optim.zero_grad()
 
-                res = self.run(doc)
+                res = self.run(deepcopy(doc))
 
                 c_loss = self._coref_criterion(res.coref_scores, res.coref_y)
                 if res.span_y and res.span_scores is not None:
@@ -452,7 +453,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         metrics_vals: list[list[float]] = []
         pbar = tqdm(docs, unit="docs", ncols=0)
         for doc in pbar:
-            res = self.run(doc, True)
+            res = self.run(deepcopy(doc), True)
             pavpu_output = pavpu_metric(
                 res.coref_scores, res.coref_y, self.config.metrics.pavpu
             )

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -284,7 +284,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         several ones to let one see the data flow.
 
         Args:
-            doc (Doc): a dictionary with the document data.
+            doc (Doc): a dataframe with the document data.
             normalize_anaphoras (bool) apply softmax or not
             to anaphoras scorer
 
@@ -301,10 +301,14 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
         # N.B. The quality of encoding is not damaged because it is done on the whole
         # article
         if self.config.active_learning.token_sampling:
-            doc = doc.create_simulation_pseudodoc()
-            encoded_doc = encoded_doc[
+            pseudo_doc = doc.create_simulation_pseudodoc()
+            del doc
+            doc = pseudo_doc
+            pseudo_encoded_doc = encoded_doc[
                 doc.simulation_token_annotations.original_subtokens_ids, :
             ]
+            del encoded_doc
+            encoded_doc = pseudo_encoded_doc
 
         # words           [n_words, span_emb]
         # cluster_ids     [n_words]

--- a/coref/test_const.py
+++ b/coref/test_const.py
@@ -19,12 +19,16 @@ def test_create_simulation_pseudodoc(dev_data: list[Doc]) -> None:
     assert doc.subwords == pseudo_doc.subwords
 
     # Create a pseudo doc from
-    doc.simulation_span_annotations.spans = [
-        (55, 56),
-        (70, 71),
-        (377, 380),
-        (411, 414),
-    ]
+    doc.simulation_token_annotations.tokens = {
+        55,
+        70,
+        377,
+        378,
+        379,
+        411,
+        412,
+        413,
+    }
     pseudo_doc = doc.create_simulation_pseudodoc()
     assert doc.document_id == pseudo_doc.document_id
     assert pseudo_doc.cased_words == [


### PR DESCRIPTION
Sample tokens in AL instead of sampling full docs. 

### Based on this PR the experiment was run:

The results show the output of the experiment where the model training was done through the token sampling vs full size documents sampling. 

The set up of experiment samples 5000 tokens per AL iteration with following strategies:
1. The token sampling is done independently through all documents. 
2. The token sampling doc exhaust strategy that always takes 5000 tokens from the subsequent docs by fully exhausting them.
3. 100 docs of interest. Independently sampling docs from 100 docs of interest. 

The experiment had 10 AL iterations and the model was trained only through two epocs

**Token sampling**

```
AL SIMULATION | round: 9, Documents: 2791, Tokens: 44712

Training

TRAINING | epoch 0 is finished
EVAL METRICS | loss: 3.34843 | f1: 0.21988 prec: 0.15033 recall: 0.40924

TRAINING | epoch 1 is finished
EVAL METRICS | loss: 3.34452 | f1: 0.24950 prec: 0.18089 recall: 0.40197

Evaluation

EVAL METRICS | loss: 3.34609 | f1: 0.25905 prec: 0.18995 recall: 0.40718
```

**Token sampling doc exhaust**

```
AL SIMULATION | round: 9, Documents: 109, Tokens: 47284

Training

TRAINING | epoch 0 is finished
EVAL METRICS | loss: 3.31335 | f1: 0.00046 prec: 0.65641 recall: 0.00023

TRAINING | epoch 1 is finished
EVAL METRICS | loss: 3.30522 | f1: 0.04984 prec: 0.65283 recall: 0.02591

Evaluation

EVAL METRICS | loss: 3.30545 | f1: 0.05118 prec: 0.64638 recall: 0.02664
```

**100 docs of interest token sampling**

```
AL SIMULATION | round: 9, Documents: 839, Tokens: 49977

Training

TRAINING | epoch 0 is finished
EVAL METRICS | loss: 3.29698 | f1: 0.48847 prec: 0.51072 recall: 0.46808

TRAINING | epoch 1 is finished
EVAL METRICS | loss: 3.32759 | f1: 0.42176 prec: 0.44440 recall: 0.40131

Evaluation

EVAL METRICS | loss: 3.33013 | f1: 0.42431 prec: 0.44283 recall: 0.40728
```
