### PR TITLE
Manifold-Learning Memory Issues Fixes; JSONL Logging

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -100,10 +100,18 @@
         # Set up for logging
         logger_name = "coref-model"
         log_folder = "data/logs/"
-        stream_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
         datetime_format = "%Y-%m-%dT%H:%M:%S%z"
         verbosity = "debug"
-
+        stream_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+            [DEFAULT.logging.jsonl_format]
+                timestamp="asctime"
+                level="levelname"
+                message="message"
+                loggerName="name"
+                processName="processName"
+                processID="process"
+                threadName="threadName"
+                threadID="thread"
 
     [DEFAULT.active_learning]
         # Active Learning parameters

--- a/config.toml
+++ b/config.toml
@@ -152,7 +152,7 @@
             docs_of_interest = 100
 
     [DEFAULT.manifold_learning]
-        enable = true
+        enable = false
         # Manifold Learning parameters
         # Loss function to use
         loss_name = "sq_rec_loss"
@@ -160,7 +160,7 @@
         loss_alpha = 1e-6
         # Metrics to display
         verbose_outputs = ["loss"]
-        reduction_ratio = 0.9
+        reduction_ratio = 0.75
         [DEFAULT.manifold_learning.standalone]
             # For separate (non-CR) use cases
             input_dimensionality = 0
@@ -264,6 +264,9 @@
         coref_model = "reduced_dimensionality"
     [reduced_dimensionality.training_params]
         device = "cuda"
+    [reduced_dimensionality.manifold_learning]
+        enable = true
+        reduction_ratio = 0.75
 
 [debug_gpu]
     [debug_gpu.model_params]

--- a/config.toml
+++ b/config.toml
@@ -148,10 +148,11 @@
         # Manifold Learning parameters
         # Loss function to use
         loss_name = "sq_rec_loss"
-        loss_alpha = 5e-6
+        loss_in_forward = true
+        loss_alpha = 1e-6
         # Metrics to display
         verbose_outputs = ["loss"]
-        reduction_ratio = 0.75
+        reduction_ratio = 0.9
         [DEFAULT.manifold_learning.standalone]
             # For separate (non-CR) use cases
             input_dimensionality = 0
@@ -227,6 +228,7 @@
         enable = true
         # Manifold Learning parameters
         loss_name = "sq_rec_loss"
+        loss_in_forward = true
         verbose_outputs = ["loss"]
         [debug.manifold_learning.standalone]
             input_dimensionality = 10

--- a/config.toml
+++ b/config.toml
@@ -266,6 +266,7 @@
         device = "cuda"
     [reduced_dimensionality.manifold_learning]
         enable = true
+        loss_alpha = 5e-6
         reduction_ratio = 0.75
 
 [debug_gpu]

--- a/config.toml
+++ b/config.toml
@@ -103,15 +103,15 @@
         datetime_format = "%Y-%m-%dT%H:%M:%S%z"
         verbosity = "debug"
         stream_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
-            [DEFAULT.logging.jsonl_format]
-                timestamp="asctime"
-                level="levelname"
-                message="message"
-                loggerName="name"
-                processName="processName"
-                processID="process"
-                threadName="threadName"
-                threadID="thread"
+        [DEFAULT.logging.jsonl_format]
+            timestamp="asctime"
+            level="levelname"
+            message="message"
+            loggerName="name"
+            processName="processName"
+            processID="process"
+            threadName="threadName"
+            threadID="thread"
 
     [DEFAULT.active_learning]
         # Active Learning parameters

--- a/config/config.py
+++ b/config/config.py
@@ -11,9 +11,12 @@ from transformers import AutoTokenizer, AutoModel
 
 from config.active_learning import ActiveLearning
 from config.config_utils import overwrite_config, get_overwrite_value
+from config.logging import Logging
 from config.metrics import Metrics
 from coref.bert import load_bert
-from config.logging import Logging
+
+# Path to the source folder (repository root) determined automatically
+__src_path__ = Path(__file__).resolve().parents[1]
 
 
 @dataclass
@@ -33,8 +36,20 @@ class Data:
     num_of_training_docs: int = field(init=False)
 
     def __post_init__(self) -> None:
+        # Process paths
+        self.train_data = self._make_data_path_absolute(path=self.train_data)
+        self.dev_data = self._make_data_path_absolute(path=self.dev_data)
+        self.test_data = self._make_data_path_absolute(path=self.test_data)
+
+        # Count the amount of training documents
         with open(self.train_data, "r") as f:
             self.num_of_training_docs = sum(1 for _ in f)
+
+    @staticmethod
+    def _make_data_path_absolute(path: Path) -> Path:
+        if not path.is_absolute():
+            path = __src_path__.joinpath(path)
+        return path
 
     @staticmethod
     def load_config(
@@ -99,9 +114,15 @@ class ManifoldLearningParamsStandalone:
 @dataclass
 class ManifoldLearningParams:
     enable: bool
+    # Loss function to use
     loss_name: str
+    # Loss multiplier to scale it accordingly
     loss_alpha: float
+    # Whether to compute loss in the forward step
+    loss_in_forward: bool
+    # The fraction by which the output dimensionality should be reduced
     reduction_ratio: float
+    # Setup for the standalone usage of the manifold learning sub-package
     standalone: ManifoldLearningParamsStandalone
     verbose_outputs: List[str] = field(default_factory=list)
 
@@ -213,6 +234,10 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
 
     @staticmethod
     def load_default_config(section: Optional[str]) -> "Config":
+        config_path = str(__src_path__.joinpath("config.toml"))
         if section is not None:
-            return Config.load_config("config.toml", section)
-        return Config.load_config("config.toml")
+            return Config.load_config(
+                config_path=config_path,
+                section=section,
+            )
+        return Config.load_config(config_path=config_path)

--- a/config/logging.py
+++ b/config/logging.py
@@ -11,7 +11,7 @@ from logging import (
 from enum import Enum
 from pathlib import Path
 from config.config_utils import overwrite_config
-from typing import Any
+from typing import Any, Dict
 
 
 class LogVerbosityMapping(Enum):
@@ -26,6 +26,7 @@ class Logging:
     logger_name: str
     verbosity: LogVerbosityMapping
     stream_format: str
+    jsonl_format: Dict[str, str]
     datetime_format: str
     log_folder: Path
     timestamp: int
@@ -36,6 +37,7 @@ class Logging:
         logger_name: str,
         verbosity: str,
         stream_format: str,
+        jsonl_format: Dict[str, str],
         datetime_format: str,
         log_folder: str,
     ) -> "Logging":
@@ -44,6 +46,7 @@ class Logging:
             logger_name=logger_name,
             verbosity=LogVerbosityMapping[verbosity],
             stream_format=stream_format,
+            jsonl_format=jsonl_format,
             datetime_format=datetime_format,
             log_folder=Path(log_folder),
             timestamp=int(time.time()),

--- a/config/logging.py
+++ b/config/logging.py
@@ -1,17 +1,15 @@
 import time
-
 from dataclasses import dataclass
+from enum import Enum
 from logging import (
     ERROR,
     WARNING,
     INFO,
     DEBUG,
 )
-
-from enum import Enum
 from pathlib import Path
+
 from config.config_utils import overwrite_config
-from typing import Any, Dict
 
 
 class LogVerbosityMapping(Enum):
@@ -26,7 +24,7 @@ class Logging:
     logger_name: str
     verbosity: LogVerbosityMapping
     stream_format: str
-    jsonl_format: Dict[str, str]
+    jsonl_format: dict[str, str]
     datetime_format: str
     log_folder: Path
     timestamp: int
@@ -37,7 +35,7 @@ class Logging:
         logger_name: str,
         verbosity: str,
         stream_format: str,
-        jsonl_format: Dict[str, str],
+        jsonl_format: dict[str, str],
         datetime_format: str,
         log_folder: str,
     ) -> "Logging":

--- a/coref/const.py
+++ b/coref/const.py
@@ -155,5 +155,4 @@ class CorefResult:
 
 @dataclass
 class ReducedDimensionalityCorefResult(CorefResult):
-    inputs: Optional[torch.Tensor] = None  # [n_subwords, initial_dim]
-    embeddings: Optional[torch.Tensor] = None  # [n_subwords, target_dim]
+    manifold_learning_loss: Optional[torch.Tensor] = None

--- a/coref/logging_utils.py
+++ b/coref/logging_utils.py
@@ -13,7 +13,8 @@ class JsonFormatter(logging.Formatter):
     @param fmt_dict: dict;
         key-value logging format attribute pairs.
         Defaults to {"message": "message"}.
-    @param time_format: str; time.strftime() format string. Default: "%Y-%m-%dT%H:%M:%S"
+    @param time_format: str; time.strftime() format string.
+        Default: "%Y-%m-%dT%H:%M:%S"
     """
 
     def __init__(
@@ -60,7 +61,7 @@ class JsonFormatter(logging.Formatter):
         if isinstance(msg_raw, str):
             message = record.getMessage()
         else:
-            # Does not supply user-supplied arguments
+            # Does not support user-supplied arguments
             # The below statement is reachable, e.g., in cases when a dictionary
             # is passed to the log message
             message = msg_raw  # type: ignore[unreachable]

--- a/coref/logging_utils.py
+++ b/coref/logging_utils.py
@@ -1,8 +1,89 @@
+import json
 import logging
-from logging import Logger
-from typing import Any
+from logging import Logger, LogRecord
+from typing import Any, Optional, Dict, cast, Union
 
 from config.logging import Logging
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    Formatter that outputs JSON strings after parsing the LogRecord.
+
+    @param fmt_dict: dict;
+        key-value logging format attribute pairs.
+        Defaults to {"message": "message"}.
+    @param time_format: str; time.strftime() format string. Default: "%Y-%m-%dT%H:%M:%S"
+    """
+
+    def __init__(
+        self,
+        fmt_dict: Optional[Dict[str, str]] = None,
+        time_format: str = "%Y-%m-%dT%H:%M:%S",
+    ) -> None:
+        super().__init__(
+            # Filler values
+            fmt=None,
+            datefmt=None,
+            style="%",
+            validate=False,
+        )
+        self.fmt_dict = (
+            fmt_dict if fmt_dict is not None else {"message": "message"}
+        )
+        self.default_time_format = time_format
+        self.default_msec_format = ""
+
+    def usesTime(self) -> bool:
+        """
+        Overwritten to look for the attribute in the format dict values instead of the fmt string.
+        """
+        return "asctime" in self.fmt_dict.values()
+
+    def formatMessage(self, record: LogRecord) -> Dict[str, str]:  # type: ignore[override]
+        """
+        Overwritten to return a dictionary of the relevant LogRecord attributes instead of a string.
+        KeyError is raised if an unknown attribute is provided in the fmt_dict.
+        """
+        return {
+            fmt_key: record.__dict__[fmt_val]
+            for fmt_key, fmt_val in self.fmt_dict.items()
+        }
+
+    def format(self, record: LogRecord) -> str:
+        """
+        Mostly the same as the parent's class method,
+        the difference being that a dict is manipulated and dumped as JSON
+        instead of a string.
+        """
+        msg_raw = record.msg
+        if isinstance(msg_raw, str):
+            message = record.getMessage()
+        else:
+            # Does not supply user-supplied arguments
+            # The below statement is reachable, e.g., in cases when a dictionary
+            # is passed to the log message
+            message = msg_raw  # type: ignore[unreachable]
+        record.message = message
+
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+
+        message_dict = self.formatMessage(record)
+
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            message_dict["exc_info"] = record.exc_text
+
+        if record.stack_info:
+            message_dict["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(message_dict, default=str)
 
 
 def get_stream_logger(
@@ -10,7 +91,6 @@ def get_stream_logger(
     experiment: str,
     **stream_handler_kw: Any,
 ) -> Logger:
-
     logger = logging.getLogger(logging_conf.logger_name)
     logger.setLevel(logging_conf.verbosity.value)
     logger.handlers.clear()
@@ -23,12 +103,28 @@ def get_stream_logger(
     if not logging_conf.log_folder.is_dir():
         logging_conf.log_folder.mkdir()
 
-    log_file = (
-        logging_conf.log_folder / f"{experiment}_{logging_conf.timestamp}"
+    log_file_unformatted = logging_conf.log_folder.joinpath(
+        f"{experiment}_{logging_conf.timestamp}.log"
     )
 
     # Define handlers
-    logger.addHandler(logging.FileHandler(log_file))
+    # Standard file handler
+    file_handler_unformatted = logging.FileHandler(log_file_unformatted)
+    logger.addHandler(file_handler_unformatted)
+
+    # Jsonlines file handler
+    file_handler_jsonl = logging.FileHandler(
+        log_file_unformatted.with_suffix(".jsonl"),
+        mode="a",
+    )
+    formatter_jsonl = JsonFormatter(
+        logging_conf.jsonl_format,
+        time_format=logging_conf.datetime_format,
+    )
+    file_handler_jsonl.setFormatter(formatter_jsonl)
+    logger.addHandler(file_handler_jsonl)
+
+    # Formatted stream handler
     sh = logging.StreamHandler(**stream_handler_kw)
     assert isinstance(logging_conf.stream_format, str) and len(
         logging_conf.stream_format,

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -432,8 +432,10 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 del res
 
                 (c_loss + s_loss).backward()
-                running_c_loss += c_loss.item()
-                running_s_loss += s_loss.item()
+                # Detaching the reported loss so that the computation
+                # graph can be cleared
+                running_c_loss += c_loss.detach().item()
+                running_s_loss += s_loss.detach().item()
 
                 del c_loss, s_loss
 

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -1,6 +1,7 @@
 import os
 import random
 import re
+from copy import deepcopy
 from datetime import datetime
 from typing import (
     Any,
@@ -14,18 +15,18 @@ from typing import (
     TYPE_CHECKING,
     TypeVar,
 )
-from copy import deepcopy
 
 import numpy as np  # type: ignore
 import torch
 import transformers  # type: ignore
 from tqdm import tqdm
 
+from config import Config
 from coref import bert, conll, utils
 from coref.anaphoricity_scorer import AnaphoricityScorer
 from coref.cluster_checker import ClusterChecker
-from config import Config
 from coref.const import CorefResult, Doc, SampledData
+from coref.logging_utils import get_stream_logger
 from coref.loss import CorefLoss
 from coref.pairwise_encoder import PairwiseEncoder
 from coref.rough_scorer import RoughScorer
@@ -33,7 +34,6 @@ from coref.span_predictor import SpanPredictor
 from coref.utils import GraphNode
 from coref.word_encoder import WordEncoder
 from uncertainty.uncertainty_metrics import pavpu_metric
-from coref.logging_utils import get_stream_logger
 
 if TYPE_CHECKING:
     from active_learning.exploration import GreedySampling

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -229,6 +229,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
                 "f1_lea": f"{tot_f1:.5f}",
                 "precision_lea": f"{tot_precision:.5f}",
                 "recall_lea": f"{tot_recall:.5f}",
+                "epoch": f"{self.epochs_trained - 1}",
             }
         }
         self._logger.info(_eval_metrics)
@@ -451,7 +452,10 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             self.epochs_trained += 1
             self.save_weights()
             if docs_dev is not None:
-                self._logger.info(f"TRAINING | epoch {epoch} is finished")
+                _train_msg = {
+                    "train_metrics": {"epoch": self.epochs_trained - 1},
+                }
+                self._logger.info(_train_msg)
                 self.evaluate(docs=docs_dev)
 
     def sample_unlabled_data(self, documents: List[Doc]) -> SampledData:

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -220,11 +220,18 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             print()
 
         avg_loss = float(running_loss / len(docs))
-        tot_f1, tot_prec, tot_rec = s_checker.total_lea
+        tot_f1, tot_precision, tot_recall = s_checker.total_lea
 
-        self._logger.info(
-            f"EVAL METRICS | loss: {avg_loss:<.5f} | f1: {tot_f1:.5f} prec: {tot_prec:.5f} recall: {tot_rec:.5f}\n"
-        )
+        # Log evaluation metrics
+        _eval_metrics = {
+            "eval_metrics": {
+                "loss": f"{avg_loss:<.5f}",
+                "f1_lea": f"{tot_f1:.5f}",
+                "precision_lea": f"{tot_precision:.5f}",
+                "recall_lea": f"{tot_recall:.5f}",
+            }
+        }
+        self._logger.info(_eval_metrics)
 
         return (
             float(running_loss / len(docs)),

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -455,7 +455,7 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
             self.save_weights()
             if docs_dev is not None:
                 _train_msg = {
-                    "train_metrics": {"epoch": self.epochs_trained - 1},
+                    "train_metrics": {"epoch": f"{self.epochs_trained - 1}"},
                 }
                 self._logger.info(_train_msg)
                 self.evaluate(docs=docs_dev)

--- a/coref/models/general_coref_model.py
+++ b/coref/models/general_coref_model.py
@@ -110,17 +110,19 @@ class GeneralCorefModel:  # pylint: disable=too-many-instance-attributes
 
     @torch.no_grad()
     def evaluate(
-        self, docs: List[Doc], word_level_conll: bool = False
-    ) -> Tuple[float, float, float, float]:
+        self,
+        docs: List[Doc],
+        word_level_conll: bool = False,
+    ) -> Tuple[float, ...]:
         """Evaluates the modes on the data split provided.
 
         Args:
-            data_split (str): one of 'dev'/'test'/'train'
+            docs (list): list of documents to evaluate
             word_level_conll (bool): if True, outputs conll files on word-level
 
         Returns:
             mean loss
-            span-level LEA: f1, precision, recal
+            span-level LEA: f1, precision, recall
         """
         self.training = False
         w_checker = ClusterChecker()

--- a/coref/models/reduced_dimensionality_coref.py
+++ b/coref/models/reduced_dimensionality_coref.py
@@ -145,9 +145,11 @@ class ReducedDimensionalityCorefModel(GeneralCorefModel):
                 del res
 
                 (c_loss + s_loss + emb_loss).backward()
-                running_c_loss += c_loss.item()
-                running_s_loss += s_loss.item()
-                running_emb_loss += emb_loss
+                # Detaching the reported loss so that the computation
+                # graph can be cleared
+                running_c_loss += c_loss.detach().item()
+                running_s_loss += s_loss.detach().item()
+                running_emb_loss += emb_loss.detach().item()
 
                 del c_loss, s_loss, emb_loss
 

--- a/coref/models/reduced_dimensionality_coref.py
+++ b/coref/models/reduced_dimensionality_coref.py
@@ -181,6 +181,7 @@ class ReducedDimensionalityCorefModel(GeneralCorefModel):
             features=bert_emb,
             config=self.config,
         ).to(self.config.training_params.device)
+        self._logger.info(f"Initialized {self.we!r}")
 
         self.rough_scorer = RoughScorer(self.we.features_out, self.config).to(
             self.config.training_params.device

--- a/coref/models/reduced_dimensionality_coref.py
+++ b/coref/models/reduced_dimensionality_coref.py
@@ -7,7 +7,6 @@ from tqdm.auto import tqdm
 from config import Config
 from coref.anaphoricity_scorer import AnaphoricityScorer
 from coref.const import ReducedDimensionalityCorefResult, Doc
-from coref.loss import CorefLoss
 from coref.models.general_coref_model import GeneralCorefModel
 from coref.pairwise_encoder import PairwiseEncoder
 from coref.rough_scorer import RoughScorer
@@ -161,7 +160,7 @@ class ReducedDimensionalityCorefModel(GeneralCorefModel):
 
                 pbar.set_description(
                     f"Epoch {epoch + 1}:"
-                    f" {doc['document_id']:26}"
+                    f" {doc.document_id:26}"
                     f" c_loss: {running_c_loss / (pbar.n + 1):<.5f}"
                     f" s_loss: {running_s_loss / (pbar.n + 1):<.5f}"
                     f" emb_loss: {running_emb_loss / (pbar.n + 1):<.5f}"
@@ -206,10 +205,3 @@ class ReducedDimensionalityCorefModel(GeneralCorefModel):
             "a_scorer": self.a_scorer,
             "sp": self.sp,
         }
-
-    def _build_criteria(self) -> None:
-        self._coref_criterion = CorefLoss(
-            self.config.training_params.bce_loss_weight
-        )
-        self._span_criterion = torch.nn.CrossEntropyLoss(reduction="sum")
-        self._manifold_criterion = self.we.manifold.loss

--- a/coref/word_encoder.py
+++ b/coref/word_encoder.py
@@ -7,7 +7,8 @@ import torch
 
 from config import Config
 from coref.const import Doc
-from manifold import BasePCA
+from manifold.base import ManifoldLearningForwardOutput
+from manifold.linear import BasePCA
 
 
 class WordEncoder(
@@ -164,7 +165,7 @@ class ReducedDimensionalityWordEncoder(WordEncoder):
         doc: Doc,
         x: torch.Tensor,
     ) -> Tuple[torch.Tensor, ...]:
-        x_reduced: torch.Tensor = self.manifold(x)
+        output: ManifoldLearningForwardOutput = self.manifold(x)
         return super(ReducedDimensionalityWordEncoder, self).run(
-            doc=doc, x=x_reduced
-        ) + (x, x_reduced)
+            doc=doc, x=output.embeddings
+        ) + (output.loss,)

--- a/coref/word_encoder.py
+++ b/coref/word_encoder.py
@@ -131,7 +131,17 @@ class WordEncoder(
 
 
 class ReducedDimensionalityWordEncoder(WordEncoder):
-    def __init__(self, features: int, config: Config):
+    """
+    Word Encoder with the ability to reduce input data dimensionality
+
+    @param features: int; input dimensionality; output dimensionality is
+        computed automatically based on the reduction_ratio specified
+        in the configuration
+    @param config: Config; current run configuration to use for initialization
+    """
+
+    def __init__(self, features: int, config: Config) -> None:
+        # Compute the output dimensionality
         self.features_in = features
         self.features_out = max(
             0,
@@ -141,6 +151,9 @@ class ReducedDimensionalityWordEncoder(WordEncoder):
             ),
         )
         super().__init__(features=self.features_out, config=config)
+
+        # Initialize the manifold learning model parts
+        # TODO: Generalize the approach for multiple methods
         assert config.manifold.enable, f"Manifold Learning must be enabled"
         config.manifold.standalone.input_dimensionality = self.features_in
         config.manifold.standalone.output_dimensionality = self.features_out

--- a/coref/word_encoder.py
+++ b/coref/word_encoder.py
@@ -160,6 +160,14 @@ class ReducedDimensionalityWordEncoder(WordEncoder):
         config.manifold.standalone.output_dimensionality = self.features_out
         self.manifold: BasePCA = BasePCA.from_config(config=config)
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"input_dim={self.features_in},"
+            f"output_dim={self.features_out},"
+            f")"
+        )
+
     def run(
         self,
         doc: Doc,

--- a/coref/word_encoder.py
+++ b/coref/word_encoder.py
@@ -165,6 +165,7 @@ class ReducedDimensionalityWordEncoder(WordEncoder):
             f"{self.__class__.__name__}("
             f"input_dim={self.features_in},"
             f"output_dim={self.features_out},"
+            f"manifold={self.manifold!r},"
             f")"
         )
 

--- a/manifold/base.py
+++ b/manifold/base.py
@@ -39,6 +39,14 @@ class ManifoldLearningModule(torch.nn.Module, metaclass=abc.ABCMeta):
         self.loss_alpha = torch.tensor(self._args.loss_alpha, dtype=torch.float)
         self.loss = get_loss_by_name(name=self._args.loss_name)
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"loss_alpha={self.loss_alpha.detach().item()},"
+            f"loss={self.loss.name},"
+            f")"
+        )
+
     @classmethod
     def from_config(cls, config: Config) -> "ManifoldLearningModule":
         """Initialization from the Config object"""

--- a/manifold/base.py
+++ b/manifold/base.py
@@ -3,11 +3,30 @@ Definition of the base module for Manifold Learning
 """
 
 import abc
+from dataclasses import dataclass, fields
+from typing import Optional, Dict
 
 import torch
 
 from config.config import ManifoldLearningParams, Config
 from .losses import get_loss_by_name
+
+
+@dataclass
+class ManifoldLearningForwardOutput:
+    embeddings: torch.Tensor
+    loss: Optional[torch.Tensor] = None
+
+    def as_dict(self) -> Dict[str, torch.Tensor]:
+        assert (
+            self.loss is not None
+        ), f"Only non-None loss is allowed to be converted"
+
+        # Done manually to avoid deep copies of tensors
+        result = {}
+        for field in fields(self):
+            result[field.name] = getattr(self, field.name)
+        return result
 
 
 class ManifoldLearningModule(torch.nn.Module, metaclass=abc.ABCMeta):
@@ -30,6 +49,6 @@ class ManifoldLearningModule(torch.nn.Module, metaclass=abc.ABCMeta):
         return self._args
 
     @abc.abstractmethod
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+    def forward(self, inputs: torch.Tensor) -> ManifoldLearningForwardOutput:
         """Placeholder for the forward method to be overridden"""
         pass

--- a/manifold/linear.py
+++ b/manifold/linear.py
@@ -10,7 +10,7 @@ import torch.optim as optim
 from tqdm.auto import tqdm
 
 from config.config import ManifoldLearningParams
-from .base import ManifoldLearningModule
+from .base import ManifoldLearningModule, ManifoldLearningForwardOutput
 from .dataset import ManifoldDataloader
 
 
@@ -26,9 +26,18 @@ class BasePCA(ManifoldLearningModule):
             params=self.parameters(), lr=self.args.standalone.learning_rate
         )
 
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        embeddings = self.pca_layer(inputs)
-        return embeddings  # [n, target_dim]
+    def forward(self, inputs: torch.Tensor) -> ManifoldLearningForwardOutput:
+        embeddings = self.pca_layer(inputs)  # [n, target_dim]
+        if self.args.loss_in_forward:
+            loss = self.evaluate_criterion(
+                inputs=inputs,
+                embeddings=embeddings,
+            )
+        else:
+            loss = None
+
+        output = ManifoldLearningForwardOutput(embeddings=embeddings, loss=loss)
+        return output
 
     def evaluate_criterion(
         self,
@@ -38,23 +47,28 @@ class BasePCA(ManifoldLearningModule):
         inputs_reconstructed = self.loss.reconstruct_from_linear(
             embeddings=embeddings,
             linear_layer=self.pca_layer,
-        )
+        )  # [n, input_dim]
         loss_ = self.loss(inputs=inputs, outputs=inputs_reconstructed)
+
+        # Multiply the output loss with a scaling factor
         loss_ *= self.loss_alpha
         return loss_
 
-    def train_step(self, inputs: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def train_step(self, inputs: torch.Tensor) -> ManifoldLearningForwardOutput:
         self.optimizer.zero_grad()
+        assert self.args.loss_in_forward, (
+            f"The loss has to be computed in the forward step "
+            f"to preserve memory"
+        )
         with torch.enable_grad():
-            embeddings = self(inputs)
-            loss_step = self.evaluate_criterion(
-                inputs=inputs,
-                embeddings=embeddings,
-            )
-            loss_step.backward()
+            result: ManifoldLearningForwardOutput = self(inputs)
+            assert (
+                result.loss is not None
+            ), f"Step loss is missing in the results"
+            result.loss.backward()
             self.optimizer.step()
             self.optimizer.zero_grad()
-        return {"embeddings": embeddings, "loss": loss_step}
+        return result
 
     def train_on_inputs(self, inputs: torch.Tensor) -> None:
         pbar = tqdm(range(self.args.standalone.epochs))
@@ -69,7 +83,7 @@ class BasePCA(ManifoldLearningModule):
                 res = self.train_step(inputs=b)
                 pf = {
                     k_: v_.detach().numpy()
-                    for k_, v_ in res.items()
+                    for k_, v_ in res.as_dict().items()
                     if k_ in self.args.verbose_outputs
                 }
                 pbar.set_postfix(pf)

--- a/manifold/tests/test_manifold_learning.py
+++ b/manifold/tests/test_manifold_learning.py
@@ -9,7 +9,7 @@ from manifold.dataset import get_embedded_2d_ellipse
 from manifold.linear import BasePCA
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def manifold_learning_test_data(config: Config) -> torch.Tensor:
     assert config.manifold.standalone.input_dimensionality is not None
     assert config.manifold.standalone.output_dimensionality is not None

--- a/manifold/tests/test_manifold_learning.py
+++ b/manifold/tests/test_manifold_learning.py
@@ -1,0 +1,41 @@
+"""
+Testing basic functionality of the manifold learning sub-package.
+"""
+import pytest
+import torch
+
+from config import Config
+from manifold.dataset import get_embedded_2d_ellipse
+from manifold.linear import BasePCA
+
+
+@pytest.fixture(scope="session")
+def manifold_learning_test_data(config: Config) -> torch.Tensor:
+    assert config.manifold.standalone.input_dimensionality is not None
+    assert config.manifold.standalone.output_dimensionality is not None
+
+    data = get_embedded_2d_ellipse(
+        dim=config.manifold.standalone.input_dimensionality,
+        a=5,
+        y0=10,
+        x0=5,
+        noise=1,
+    )
+    assert data.shape[1] == config.manifold.standalone.input_dimensionality
+    return data
+
+
+def test_standalone_manifold_learning(
+    config: Config,
+    manifold_learning_test_data: torch.Tensor,
+) -> None:
+    # Run BasePCA
+    pca_custom = BasePCA.from_config(
+        config=config,
+    )
+    pca_custom.train_on_inputs(inputs=manifold_learning_test_data)
+    output = pca_custom(manifold_learning_test_data)
+    assert (
+        output.embeddings.shape[1]
+        == config.manifold.standalone.output_dimensionality
+    )

--- a/rci_run.batch
+++ b/rci_run.batch
@@ -6,10 +6,11 @@
 echo "Preparing environment..."
 
 # Initialization via the installation path
+SRC_PATH="/home/$(whoami)/orchid/rci_run.batch"
 ENV_PATH="/home/$(whoami)/venv/orchid/bin/activate"
 echo "Using env from ${ENV_PATH}"
-
-source $ENV_PATH
+# shellcheck source="${SRC_PATH}"
+. "${ENV_PATH}"
 
 # ML dependencies
 echo "Activating the Torch module"


### PR DESCRIPTION
* Fixing the memory issues with the manifold-learning-based approaches;
* Dumping logs into JSONL files as well, allowing one to work with them later to extract, e.g., training/evaluation metrics for analysis.

The logs are saved next to unformatted ones under the same name:
<img width="414" alt="Screenshot 2023-03-17 at 1 07 23" src="https://user-images.githubusercontent.com/26472774/225779113-5f7d2203-5594-43e3-8c77-dc87a7250da3.png">

The core message is written as in the example below:
<img width="1449" alt="Screenshot 2023-03-17 at 1 08 29" src="https://user-images.githubusercontent.com/26472774/225779225-4079853c-0df8-4dfb-82a4-3e7c42e337a8.png">

